### PR TITLE
[#14] 모임 api 추가

### DIFF
--- a/src/main/java/findme/dangdangcrew/DangdangcrewApplication.java
+++ b/src/main/java/findme/dangdangcrew/DangdangcrewApplication.java
@@ -2,8 +2,10 @@ package findme.dangdangcrew;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class DangdangcrewApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/findme/dangdangcrew/meeting/controller/MeetingController.java
+++ b/src/main/java/findme/dangdangcrew/meeting/controller/MeetingController.java
@@ -1,11 +1,63 @@
 package findme.dangdangcrew.meeting.controller;
 
+import findme.dangdangcrew.meeting.dto.MeetingApplicationResponseDto;
+import findme.dangdangcrew.meeting.dto.MeetingApplicationUpdateRequestDto;
+import findme.dangdangcrew.meeting.dto.MeetingDetailResponseDto;
+import findme.dangdangcrew.meeting.dto.MeetingRequestDto;
+import findme.dangdangcrew.meeting.service.MeetingService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
-@RequestMapping("/api/v1")
+@RequestMapping("/api/v1/meetings")
 @RequiredArgsConstructor
 public class MeetingController {
+
+    private final MeetingService meetingService;
+
+    @PostMapping("/{userId}")
+    public ResponseEntity<MeetingApplicationResponseDto> createMeeting(@RequestBody MeetingRequestDto dto, @PathVariable("userId") Long userId){
+        MeetingApplicationResponseDto response = meetingService.create(dto, userId);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/{meetingId}")
+    public ResponseEntity<MeetingDetailResponseDto> getMeetingDetail(@PathVariable("meetingId") Long meetingId){
+        MeetingDetailResponseDto response = meetingService.readByMeetingId(meetingId);
+        return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/{meetingId}/{userId}")
+    public ResponseEntity<MeetingApplicationResponseDto> applyMeeting(@PathVariable("meetingId") Long meetingId, @PathVariable("userId") Long userId){
+        MeetingApplicationResponseDto response = meetingService.applyMeetingByMeetingId(meetingId, userId);
+        return ResponseEntity.ok(response);
+    }
+
+    @PutMapping("/{metingId}/{userId}/cancel")
+    public ResponseEntity<MeetingApplicationResponseDto> cancelMeetingApplication(@PathVariable("metingId") Long meetingId, @PathVariable("userId") Long userId){
+        MeetingApplicationResponseDto response = meetingService.cancelMeetingApplication(meetingId, userId);
+        return ResponseEntity.ok(response);
+    }
+
+    @PutMapping("/{meetingId}/status")
+    public ResponseEntity<MeetingApplicationResponseDto> updateApplicationStatusByLeader(@PathVariable("meetingId") Long meetingId,
+                                                                               MeetingApplicationUpdateRequestDto dto){
+        MeetingApplicationResponseDto response = meetingService.changeMeetingApplicationStatusByLeader(meetingId, dto);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/{meetingId}/applications")
+    public ResponseEntity<List<MeetingApplicationResponseDto>> getAllMeetingApplications(@PathVariable("meetingId") Long meetingId){
+        List<MeetingApplicationResponseDto> response = meetingService.readAllApplications(meetingId);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/{meetingId}/confirmed")
+    public ResponseEntity<List<MeetingApplicationResponseDto>> getConfirmedMeetingApplications(@PathVariable("meetingId") Long meetingId){
+        List<MeetingApplicationResponseDto> response = meetingService.readAllConfirmed(meetingId);
+        return ResponseEntity.ok(response);
+    }
 }

--- a/src/main/java/findme/dangdangcrew/meeting/dto/MeetingApplicationResponseDto.java
+++ b/src/main/java/findme/dangdangcrew/meeting/dto/MeetingApplicationResponseDto.java
@@ -1,0 +1,17 @@
+package findme.dangdangcrew.meeting.dto;
+
+import findme.dangdangcrew.meeting.entity.enums.UserMeetingStatus;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class MeetingApplicationResponseDto {
+    private Long userId;
+
+    private String userName;
+
+    private Long meetingId;
+
+    private UserMeetingStatus status;
+}

--- a/src/main/java/findme/dangdangcrew/meeting/dto/MeetingApplicationUpdateRequestDto.java
+++ b/src/main/java/findme/dangdangcrew/meeting/dto/MeetingApplicationUpdateRequestDto.java
@@ -1,0 +1,13 @@
+package findme.dangdangcrew.meeting.dto;
+
+import findme.dangdangcrew.meeting.entity.enums.UserMeetingStatus;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class MeetingApplicationUpdateRequestDto {
+    private Long userId;
+
+    private UserMeetingStatus status;
+}

--- a/src/main/java/findme/dangdangcrew/meeting/dto/MeetingBasicResponseDto.java
+++ b/src/main/java/findme/dangdangcrew/meeting/dto/MeetingBasicResponseDto.java
@@ -5,7 +5,7 @@ import lombok.Getter;
 
 @Getter
 @Builder
-public class MeetingListResponseDto {
+public class MeetingBasicResponseDto {
     private Long meetingId;
 
     private String meetingName;

--- a/src/main/java/findme/dangdangcrew/meeting/dto/MeetingDetailResponseDto.java
+++ b/src/main/java/findme/dangdangcrew/meeting/dto/MeetingDetailResponseDto.java
@@ -1,0 +1,22 @@
+package findme.dangdangcrew.meeting.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class MeetingDetailResponseDto {
+    private Long meetingId;
+
+    private String meetingName;
+
+    private String information;
+
+    private Integer maxPeople;
+
+    private Integer curPeople;
+
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/findme/dangdangcrew/meeting/dto/MeetingListResponseDto.java
+++ b/src/main/java/findme/dangdangcrew/meeting/dto/MeetingListResponseDto.java
@@ -3,20 +3,14 @@ package findme.dangdangcrew.meeting.dto;
 import lombok.Builder;
 import lombok.Getter;
 
-import java.time.LocalDateTime;
-
 @Getter
 @Builder
-public class MeetingResponseDto {
+public class MeetingListResponseDto {
     private Long meetingId;
 
     private String meetingName;
 
-    private String information;
-
     private Integer maxPeople;
 
     private Integer curPeople;
-
-    private LocalDateTime createdAt;
 }

--- a/src/main/java/findme/dangdangcrew/meeting/dto/MeetingRequestDto.java
+++ b/src/main/java/findme/dangdangcrew/meeting/dto/MeetingRequestDto.java
@@ -2,8 +2,6 @@ package findme.dangdangcrew.meeting.dto;
 
 import lombok.Getter;
 
-import java.time.LocalDateTime;
-
 @Getter
 public class MeetingRequestDto {
     private String meetingName;
@@ -11,8 +9,4 @@ public class MeetingRequestDto {
     private String information;
 
     private Integer maxPeople;
-
-    private Integer curPeople;
-
-    private LocalDateTime createdAt;
 }

--- a/src/main/java/findme/dangdangcrew/meeting/entity/Meeting.java
+++ b/src/main/java/findme/dangdangcrew/meeting/entity/Meeting.java
@@ -37,12 +37,16 @@ public class Meeting {
     public void increaseCurPeople() {
         if(this.curPeople <= maxPeople) {
             this.curPeople++;
+        } else {
+            throw new IllegalArgumentException("현재 인원은 최대 인원(" + this.maxPeople + "명)을 초과할 수 없습니다.");
         }
     }
 
     public void decreaseCurPeople() {
         if(this.curPeople > 0){
             this.curPeople--;
+        } else {
+            throw new IllegalArgumentException("현재 인원은 1명 미만이 될 수 없습니다.");
         }
     }
 }

--- a/src/main/java/findme/dangdangcrew/meeting/entity/Meeting.java
+++ b/src/main/java/findme/dangdangcrew/meeting/entity/Meeting.java
@@ -2,6 +2,8 @@ package findme.dangdangcrew.meeting.entity;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 
@@ -9,20 +11,38 @@ import java.time.LocalDateTime;
 @Table(name = "meeting")
 @Builder
 @Getter
+@EntityListeners(AuditingEntityListener.class)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 public class Meeting {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long meetingId;
+    private Long id;
 
+    @Column(nullable = false)
     private String meetingName;
 
+    @Column(nullable = false)
     private String information;
 
+    @Column(nullable = false)
     private Integer maxPeople;
 
-    private Integer curPeople;
+    @Column(nullable = false, columnDefinition = "INT DEFAULT 1")
+    private Integer curPeople = 1;
 
+    @CreatedDate
     private LocalDateTime createdAt;
+
+    public void increaseCurPeople() {
+        if(this.curPeople <= maxPeople) {
+            this.curPeople++;
+        }
+    }
+
+    public void decreaseCurPeople() {
+        if(this.curPeople > 0){
+            this.curPeople--;
+        }
+    }
 }

--- a/src/main/java/findme/dangdangcrew/meeting/entity/UserMeeting.java
+++ b/src/main/java/findme/dangdangcrew/meeting/entity/UserMeeting.java
@@ -1,0 +1,25 @@
+package findme.dangdangcrew.meeting.entity;
+
+import findme.dangdangcrew.user.entity.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "user_meeting")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class UserMeeting {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long userMeetingId;
+
+    @ManyToOne
+    private Meeting meeting;
+
+    @ManyToOne
+    private User user;
+}

--- a/src/main/java/findme/dangdangcrew/meeting/entity/UserMeeting.java
+++ b/src/main/java/findme/dangdangcrew/meeting/entity/UserMeeting.java
@@ -1,25 +1,33 @@
 package findme.dangdangcrew.meeting.entity;
 
+import findme.dangdangcrew.meeting.entity.enums.UserMeetingStatus;
 import findme.dangdangcrew.user.entity.User;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Entity
 @Getter
 @Table(name = "user_meeting")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
+@Builder
 public class UserMeeting {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long userMeetingId;
+    private Long id;
 
     @ManyToOne
+    @JoinColumn(name = "meeting_id")
     private Meeting meeting;
 
     @ManyToOne
+    @JoinColumn(name = "user_id")
     private User user;
+
+    @Enumerated(EnumType.STRING)
+    private UserMeetingStatus status = UserMeetingStatus.WAITING;
+
+    public void updateStatus(UserMeetingStatus newStatus) {
+        this.status = newStatus;
+    }
 }

--- a/src/main/java/findme/dangdangcrew/meeting/entity/enums/UserMeetingStatus.java
+++ b/src/main/java/findme/dangdangcrew/meeting/entity/enums/UserMeetingStatus.java
@@ -1,0 +1,8 @@
+package findme.dangdangcrew.meeting.entity.enums;
+
+public enum UserMeetingStatus {
+    CANCELLED, // 예약취소
+    CONFIRMED, // 확정
+    WAITING, // 신청 후 대기 중
+    LEADER // 모임 생성자
+}

--- a/src/main/java/findme/dangdangcrew/meeting/mapper/MeetingMapper.java
+++ b/src/main/java/findme/dangdangcrew/meeting/mapper/MeetingMapper.java
@@ -1,12 +1,14 @@
 package findme.dangdangcrew.meeting.mapper;
 
+import findme.dangdangcrew.meeting.dto.MeetingListResponseDto;
 import findme.dangdangcrew.meeting.dto.MeetingRequestDto;
-import findme.dangdangcrew.meeting.dto.MeetingResponseDto;
+import findme.dangdangcrew.meeting.dto.MeetingDetailResponseDto;
 import findme.dangdangcrew.meeting.entity.Meeting;
 import lombok.Builder;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Builder
 @Component
@@ -21,14 +23,25 @@ public class MeetingMapper {
                 .build();
     }
 
-    public MeetingResponseDto toDto(Meeting meeting) {
-        return MeetingResponseDto.builder()
-                .meetingId(meeting.getMeetingId())
+    public MeetingDetailResponseDto toDto(Meeting meeting) {
+        return MeetingDetailResponseDto.builder()
+                .meetingId(meeting.getId())
                 .meetingName(meeting.getMeetingName())
                 .information(meeting.getInformation())
                 .maxPeople(meeting.getMaxPeople())
                 .curPeople(meeting.getCurPeople())
                 .createdAt(meeting.getCreatedAt())
                 .build();
+    }
+
+    public List<MeetingListResponseDto> toListDto(List<Meeting> meetings){
+        return meetings.stream()
+                .map(meeting -> MeetingListResponseDto.builder()
+                            .meetingId(meeting.getId())
+                            .meetingName(meeting.getMeetingName())
+                            .maxPeople(meeting.getMaxPeople())
+                            .curPeople(meeting.getCurPeople())
+                            .build())
+            .toList();
     }
 }

--- a/src/main/java/findme/dangdangcrew/meeting/mapper/MeetingMapper.java
+++ b/src/main/java/findme/dangdangcrew/meeting/mapper/MeetingMapper.java
@@ -1,13 +1,11 @@
 package findme.dangdangcrew.meeting.mapper;
 
-import findme.dangdangcrew.meeting.dto.MeetingListResponseDto;
-import findme.dangdangcrew.meeting.dto.MeetingRequestDto;
-import findme.dangdangcrew.meeting.dto.MeetingDetailResponseDto;
+import findme.dangdangcrew.meeting.dto.*;
 import findme.dangdangcrew.meeting.entity.Meeting;
+import findme.dangdangcrew.meeting.entity.UserMeeting;
 import lombok.Builder;
 import org.springframework.stereotype.Component;
 
-import java.time.LocalDateTime;
 import java.util.List;
 
 @Builder
@@ -18,8 +16,7 @@ public class MeetingMapper {
                 .meetingName(dto.getMeetingName())
                 .information(dto.getInformation())
                 .maxPeople(dto.getMaxPeople())
-                .curPeople(dto.getCurPeople())
-                .createdAt(LocalDateTime.now())
+                .curPeople(1)
                 .build();
     }
 
@@ -34,14 +31,29 @@ public class MeetingMapper {
                 .build();
     }
 
-    public List<MeetingListResponseDto> toListDto(List<Meeting> meetings){
+    public List<MeetingBasicResponseDto> toListDto(List<Meeting> meetings){
         return meetings.stream()
-                .map(meeting -> MeetingListResponseDto.builder()
+                .map(meeting -> MeetingBasicResponseDto.builder()
                             .meetingId(meeting.getId())
                             .meetingName(meeting.getMeetingName())
                             .maxPeople(meeting.getMaxPeople())
                             .curPeople(meeting.getCurPeople())
                             .build())
             .toList();
+    }
+
+    public MeetingApplicationResponseDto toApplicationDto(UserMeeting userMeeting) {
+        return MeetingApplicationResponseDto.builder()
+                .meetingId(userMeeting.getMeeting().getId())
+                .userId(userMeeting.getUser().getId())
+                .userName(userMeeting.getUser().getName())
+                .status(userMeeting.getStatus())
+                .build();
+    }
+
+    public List<MeetingApplicationResponseDto> toListApplicationDto(List<UserMeeting> userMeetings) {
+        return userMeetings.stream()
+                .map(this::toApplicationDto)
+                .toList();
     }
 }

--- a/src/main/java/findme/dangdangcrew/meeting/repository/UserMeetingRepository.java
+++ b/src/main/java/findme/dangdangcrew/meeting/repository/UserMeetingRepository.java
@@ -1,0 +1,16 @@
+package findme.dangdangcrew.meeting.repository;
+
+import findme.dangdangcrew.meeting.entity.UserMeeting;
+import findme.dangdangcrew.meeting.entity.enums.UserMeetingStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface UserMeetingRepository extends JpaRepository<UserMeeting, Long> {
+    Optional<UserMeeting> findFirstByStatusAndMeeting_Id(UserMeetingStatus status, Long meetingId);
+
+    List<UserMeeting> findAllByStatusAndMeeting_Id(UserMeetingStatus status, Long meetingId);
+
+    Optional<UserMeeting> findFirstByMeeting_IdAndUser_Id(Long meetingId, Long userId);
+}

--- a/src/main/java/findme/dangdangcrew/meeting/service/MeetingService.java
+++ b/src/main/java/findme/dangdangcrew/meeting/service/MeetingService.java
@@ -1,11 +1,149 @@
 package findme.dangdangcrew.meeting.service;
 
+import findme.dangdangcrew.global.publisher.EventPublisher;
+import findme.dangdangcrew.meeting.dto.*;
+import findme.dangdangcrew.meeting.entity.Meeting;
+import findme.dangdangcrew.meeting.entity.UserMeeting;
+import findme.dangdangcrew.meeting.entity.enums.UserMeetingStatus;
+import findme.dangdangcrew.meeting.mapper.MeetingMapper;
+import findme.dangdangcrew.meeting.repository.MeetingRepository;
+import findme.dangdangcrew.notification.event.ApplyEvent;
+import findme.dangdangcrew.user.entity.User;
+import findme.dangdangcrew.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+
+/*
+ * TODO
+ *  1. when : 장소 도메인 작성 후
+ *     what : 연관관계 매핑, 장소별 모임 조회 메소드 작성
+ *  2. when : 채팅방 구현이 어느정도 된 후
+ *     what : 모임 채팅방 참여 api
+ *  3. 내가 참여한 모임 조회 구현
+ * */
 
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class MeetingService {
+
+    private final MeetingRepository meetingRepository;
+    private final MeetingMapper meetingMapper;
+    private final UserMeetingService userMeetingService;
+    private final UserRepository userRepository;
+    private final EventPublisher eventPublisher;
+
+    public Meeting findById(Long id) {
+        return meetingRepository.findById(id).orElseThrow(() -> new IllegalArgumentException("해당 미팅이 존재하지 않습니다."));
+    }
+
+    /*
+     * TODO
+     *  when : 유저 로그인 / 토큰 구현된 후
+     *  what : 매개변수 부분 수정
+     * */
+    // 모임 생성
+    @Transactional
+    public MeetingApplicationResponseDto create(MeetingRequestDto meetingRequestDto, Long userId) {
+        Meeting meeting = meetingMapper.toEntity(meetingRequestDto);
+        meeting = meetingRepository.save(meeting);
+
+        User user = userRepository.findById(userId).orElseThrow();
+        UserMeeting userMeeting = userMeetingService.saveUserAndMeeting(meeting, user, UserMeetingStatus.LEADER);
+
+        return meetingMapper.toApplicationDto(userMeeting);
+    }
+
+    // 모임 상세 조회
+    public MeetingDetailResponseDto readByMeetingId(Long id) {
+        Meeting meeting = findById(id);
+        return meetingMapper.toDto(meeting);
+    }
+
+    /*
+    * TODO
+    *  when : 유저 로그인 / 토큰 구현된 후
+    *  what : 매개변수 부분 수정
+    * */
+    // 모임 참가 신청
+    @Transactional
+    public MeetingApplicationResponseDto applyMeetingByMeetingId(Long id, Long userId) {
+        Meeting meeting = findById(id);
+        User user = userRepository.findById(userId).orElseThrow();
+
+        UserMeeting userMeeting = userMeetingService.saveUserAndMeeting(meeting, user, UserMeetingStatus.WAITING);
+        User leader = userMeetingService.findLeader(meeting);
+
+        eventPublisher.publisher(new ApplyEvent(leader.getId(), user.getNickname(), user.getId(), meeting.getId(), meeting.getMeetingName()));
+
+        return meetingMapper.toApplicationDto(userMeeting);
+    }
+
+    // 모임 참가 취소
+    @Transactional
+    public MeetingApplicationResponseDto cancelMeetingApplication(Long id, Long userId) {
+        Meeting meeting = findById(id);
+        User user = userRepository.findById(userId).orElseThrow();
+
+        UserMeeting userMeeting = userMeetingService.cancelMeetingApplication(meeting, user);
+
+        /*
+         * TODO
+         *  when : 유저 도메인에 평가점수 추가 + 평가 도메인 작성된 후
+         *  what : 확정 후 취소했을 경우 평가 점수 감점
+         * */
+        return meetingMapper.toApplicationDto(userMeeting);
+    }
+
+    // 모임 신청 상태 변경(모임 생성자)
+    @Transactional
+    public MeetingApplicationResponseDto changeMeetingApplicationStatusByLeader(Long id, MeetingApplicationUpdateRequestDto dto){
+        Meeting meeting = findById(id);
+        User user = userRepository.findById(dto.getUserId()).orElseThrow();
+
+        /*
+         * TODO
+         *  1. when : 유저 로그인 / 토큰 구현된 후
+         *     what : 로그인 유저가 해당 모임 리더인지 확인
+         * */
+
+        UserMeeting userMeeting = userMeetingService.findUserMeeting(meeting, user);
+        UserMeetingStatus currentStatus = userMeeting.getStatus();
+        UserMeetingStatus newStatus = dto.getStatus();
+
+        if (currentStatus == UserMeetingStatus.CANCELLED && newStatus == UserMeetingStatus.CONFIRMED) {
+            meeting.increaseCurPeople();
+        } else if (currentStatus == UserMeetingStatus.CONFIRMED && newStatus == UserMeetingStatus.CANCELLED) {
+            meeting.decreaseCurPeople();
+        }
+
+        userMeeting = userMeetingService.updateMeetingApplication(meeting, user, dto.getStatus());
+        return meetingMapper.toApplicationDto(userMeeting);
+    }
+
+    // 모임 신청자 조회
+    public List<MeetingApplicationResponseDto> readAllApplications(Long id) {
+        Meeting meeting = findById(id);
+
+        /*
+         * TODO
+         *  when : 유저 로그인 / 토큰 구현된 후
+         *  what : 로그인 유저가 해당 모임 리더인지 확인
+         * */
+
+        List<UserMeeting> userMeetings = userMeetingService.findWaitingByMeetingId(meeting);
+        return meetingMapper.toListApplicationDto(userMeetings);
+    }
+
+    // 모임 확정자 조회
+    public List<MeetingApplicationResponseDto> readAllConfirmed(Long id) {
+        Meeting meeting = findById(id);
+
+        List<UserMeeting> userMeetings = userMeetingService.findConfirmedByMeetingId(meeting);
+        return meetingMapper.toListApplicationDto(userMeetings);
+    }
 }

--- a/src/main/java/findme/dangdangcrew/meeting/service/MeetingService.java
+++ b/src/main/java/findme/dangdangcrew/meeting/service/MeetingService.java
@@ -115,7 +115,8 @@ public class MeetingService {
         UserMeetingStatus currentStatus = userMeeting.getStatus();
         UserMeetingStatus newStatus = dto.getStatus();
 
-        if (currentStatus == UserMeetingStatus.CANCELLED && newStatus == UserMeetingStatus.CONFIRMED) {
+        if ((currentStatus == UserMeetingStatus.CANCELLED || currentStatus == UserMeetingStatus.WAITING)
+                && newStatus == UserMeetingStatus.CONFIRMED) {
             meeting.increaseCurPeople();
         } else if (currentStatus == UserMeetingStatus.CONFIRMED && newStatus == UserMeetingStatus.CANCELLED) {
             meeting.decreaseCurPeople();

--- a/src/main/java/findme/dangdangcrew/meeting/service/UserMeetingService.java
+++ b/src/main/java/findme/dangdangcrew/meeting/service/UserMeetingService.java
@@ -1,0 +1,74 @@
+package findme.dangdangcrew.meeting.service;
+
+import findme.dangdangcrew.meeting.entity.Meeting;
+import findme.dangdangcrew.meeting.entity.UserMeeting;
+import findme.dangdangcrew.meeting.entity.enums.UserMeetingStatus;
+import findme.dangdangcrew.meeting.repository.UserMeetingRepository;
+import findme.dangdangcrew.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class UserMeetingService {
+
+    private final UserMeetingRepository userMeetingRepository;
+
+    public UserMeeting findUserMeeting(Meeting meeting, User user) {
+        return userMeetingRepository.findFirstByMeeting_IdAndUser_Id(meeting.getId(), user.getId())
+                .orElseThrow(() -> new IllegalArgumentException("해당 유저는 이 모임에 속해있지 않습니다."));
+    }
+
+    // 유저가 미팅에 참가
+    @Transactional
+    public UserMeeting saveUserAndMeeting(Meeting meeting, User user, UserMeetingStatus status) {
+        UserMeeting userMeeting = UserMeeting.builder()
+                .meeting(meeting)
+                .user(user)
+                .status(status)
+                .build();
+
+        return userMeetingRepository.save(userMeeting);
+    }
+
+    // 리더 찾기
+    public User findLeader(Meeting meeting) {
+        UserMeeting userMeeting = userMeetingRepository.findFirstByStatusAndMeeting_Id(UserMeetingStatus.LEADER, meeting.getId())
+                .orElseThrow(() -> new IllegalArgumentException("해당 모임의 리더를 찾을 수 없습니다."));
+        return userMeeting.getUser();
+    }
+
+    // 신청 취소 - 일반 유저
+    @Transactional
+    public UserMeeting cancelMeetingApplication(Meeting meeting, User user) {
+        UserMeeting userMeeting = findUserMeeting(meeting, user);
+        if(userMeeting.getStatus() == UserMeetingStatus.WAITING) {
+            userMeeting.updateStatus(UserMeetingStatus.CANCELLED);
+            return userMeeting;
+        } else {
+            throw new IllegalArgumentException("취소할 수 없습니다.");
+        }
+    }
+
+    // 신청 상태 변경 - 모임 생성자
+    @Transactional
+    public UserMeeting updateMeetingApplication(Meeting meeting, User user, UserMeetingStatus status) {
+        UserMeeting userMeeting = findUserMeeting(meeting, user);
+        userMeeting.updateStatus(status);
+        return userMeeting;
+    }
+
+    // 모임 신청자 전체 조회 - 모임 생성자
+    public List<UserMeeting> findWaitingByMeetingId(Meeting meeting){
+        return userMeetingRepository.findAllByStatusAndMeeting_Id(UserMeetingStatus.WAITING, meeting.getId());
+    }
+
+    // 모임 확정자 전제 조회 - 모임 생성자
+    public List<UserMeeting> findConfirmedByMeetingId(Meeting meeting){
+        return userMeetingRepository.findAllByStatusAndMeeting_Id(UserMeetingStatus.CONFIRMED, meeting.getId());
+    }
+}


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [X] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 문서 수정
- [ ] 코드 리팩토링
- [ ] 테스트 코드 추가 및 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
dev

### 이슈
- closed #14 

### 변경 사항
1. 모임 생성 구현
- 모임 생성시 현재 인원수는 기본값 1(생성자), createdAt은 생성된 날짜에 맞게 entity가 생길 수 있게 구현합니다.
- 생성시 user_meeting에는 모임 생성자의 status가 LEADER로 들어갈 수 있도록 하였습니다.

2. 모임 상세 조회
- 모임 id 값으로 해당 모임에 대한 자세한 내용을 조회할 수 있도록 구현하였습니다.

3. 모임 참가 신청 구현
- 참가 신청시 user_meeting에는 해당 유저의 status가 WAITING으로 들어갈 수 있도록 구현하였습니다.

4. 모임 참가 취소 구현
- 참가 취소시 해당 유저의 user_meeting status값이 CANCELLED로 변경되도록 구현하였습니다.

5. (모임 생성자) 모임 신청 상태 변경
- 모임 신청 상태를 모임 생성자가 변경할 수 있습니다.
- 모임 신청 상태가 변경될 경우 이전 상태와 변경 후 상태를 비교하여 모임의 현재 인원이 변경되도록 구현하였습니다.

6. (모임 생성자) 모임 신청자 조회
- 모임 생성자는 전체 모임 신청자를 조회할 수 있습니다.

7. 모임 확정자 조회
- 모임 생성자 및 유저는 모임 확정자를 조회할 수 있습니다.

### 테스트 결과
1. 모임 생성
<img width="719" alt="image" src="https://github.com/user-attachments/assets/18354ed4-5875-4649-9761-76190a29716e" />


2. 모임 상세 조회
<img width="719" alt="image" src="https://github.com/user-attachments/assets/794a3b1e-abd3-40ec-9a90-8625b7090fc2" />


3. 모임 참가 신청
<img width="724" alt="image" src="https://github.com/user-attachments/assets/f714758e-d81c-439a-aa35-8d58f4db8943" />


4. 모임 참가 취소
<img width="720" alt="image" src="https://github.com/user-attachments/assets/76cbac14-3d00-46f6-b26c-ddcdea65a2fa" />


5. 모임 신청 상태 변경
<img width="718" alt="image" src="https://github.com/user-attachments/assets/1f285235-5452-445c-b192-9a76604dbb8f" />


6. 모임 신청자 조회
<img width="720" alt="image" src="https://github.com/user-attachments/assets/b651a42e-6064-441f-8612-fe839bac2c72" />


7. 모임 확정자 조회
<img width="719" alt="image" src="https://github.com/user-attachments/assets/b147b710-a7ce-4560-b36f-b7b20b5874d8" />