### PR TITLE
[#18] sse 알림 기능 추가 

### DIFF
--- a/src/main/java/findme/dangdangcrew/sse/controller/SseController.java
+++ b/src/main/java/findme/dangdangcrew/sse/controller/SseController.java
@@ -1,0 +1,33 @@
+package findme.dangdangcrew.sse.controller;
+
+import findme.dangdangcrew.sse.dto.EventPayload;
+import findme.dangdangcrew.sse.service.SseService;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@Tag(name = "[SSE] SSE API", description = "사용자에게 실시간으로 알림을 리턴합니다.")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/sse")
+@Log4j2
+public class SseController {
+    private final SseService sseService;
+
+    // http://localhost:8080/api/v1/sse/subscribe
+    @GetMapping(value = "/subscribe",produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public SseEmitter subscribe(@RequestParam("userId") Long userId){
+        log.info("userId: {}", userId);
+        return sseService.subscribe(userId);
+    }
+
+    @PostMapping("/broadcast")
+    public ResponseEntity<?> broadcast(@RequestBody EventPayload eventPayload){
+        sseService.broadcast(eventPayload);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/findme/dangdangcrew/sse/dto/EventPayload.java
+++ b/src/main/java/findme/dangdangcrew/sse/dto/EventPayload.java
@@ -1,0 +1,10 @@
+package findme.dangdangcrew.sse.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Getter
+public class EventPayload {
+    private String message;
+}

--- a/src/main/java/findme/dangdangcrew/sse/infrastructure/ClockHolder.java
+++ b/src/main/java/findme/dangdangcrew/sse/infrastructure/ClockHolder.java
@@ -1,0 +1,5 @@
+package findme.dangdangcrew.sse.infrastructure;
+
+public interface ClockHolder {
+    long mills();
+}

--- a/src/main/java/findme/dangdangcrew/sse/infrastructure/SystemClockHolder.java
+++ b/src/main/java/findme/dangdangcrew/sse/infrastructure/SystemClockHolder.java
@@ -1,0 +1,13 @@
+package findme.dangdangcrew.sse.infrastructure;
+
+import org.springframework.stereotype.Component;
+
+import java.time.Clock;
+
+@Component
+public class SystemClockHolder implements ClockHolder{
+    @Override
+    public long mills() {
+        return Clock.systemUTC().millis();
+    }
+}

--- a/src/main/java/findme/dangdangcrew/sse/repository/EmitterRepository.java
+++ b/src/main/java/findme/dangdangcrew/sse/repository/EmitterRepository.java
@@ -1,0 +1,18 @@
+package findme.dangdangcrew.sse.repository;
+
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.util.Map;
+
+public interface EmitterRepository {
+    SseEmitter save(String eventId, SseEmitter sseEmitter);
+    void saveEvent(String eventId, Object event);
+    Map<String, SseEmitter> findAllEmittersStartWithUserId(Long userId);
+    Map<String, Object> findAllEventsStartWithUserId(Long userId);
+    void deleteByEventId(String eventId);
+    void deleteAllEmittersStartWithUserId(Long userId);
+    void deleteAllEventsStartWithUserId(Long userId);
+    Map<String, SseEmitter> findAllEmitters();
+
+    SseEmitter findEmitterByUserId(Long userId);
+}

--- a/src/main/java/findme/dangdangcrew/sse/repository/SseEmitterRepository.java
+++ b/src/main/java/findme/dangdangcrew/sse/repository/SseEmitterRepository.java
@@ -1,0 +1,72 @@
+package findme.dangdangcrew.sse.repository;
+
+import org.springframework.stereotype.Repository;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+
+@Repository
+public class SseEmitterRepository implements EmitterRepository{
+    private final Map<String, SseEmitter> emitters = new ConcurrentHashMap<>();
+    private final Map<String, Object> events = new ConcurrentHashMap<>();
+
+    @Override
+    public SseEmitter save(String eventId, SseEmitter sseEmitter) {
+        emitters.put(eventId, sseEmitter);
+        return sseEmitter;
+    }
+
+    @Override
+    public void saveEvent(String eventId, Object event) {
+        events.put(eventId, event);
+    }
+
+    @Override
+    public Map<String, SseEmitter> findAllEmittersStartWithUserId(Long userId) {
+        return emitters.entrySet().stream()
+                .filter(e -> e.getKey().startsWith(userId.toString()))
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+
+    @Override
+    public Map<String, Object> findAllEventsStartWithUserId(Long userId) {
+        return events.entrySet().stream()
+                .filter(e->e.getKey().startsWith(userId.toString()))
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+
+    @Override
+    public void deleteByEventId(String eventId) {
+        emitters.remove(eventId);
+    }
+
+    @Override
+    public void deleteAllEmittersStartWithUserId(Long userId) {
+        emitters.forEach((k,v) -> {
+            if(k.startsWith(userId.toString())) events.remove(k);
+        });
+    }
+
+    @Override
+    public void deleteAllEventsStartWithUserId(Long userId) {
+        events.forEach((k,v) ->{
+            if(k.startsWith(userId.toString())) events.remove(k);
+        });
+    }
+
+    @Override
+    public Map<String, SseEmitter> findAllEmitters() {
+        return emitters;
+    }
+
+    @Override
+    public SseEmitter findEmitterByUserId(Long userId) {
+        return emitters.entrySet().stream()
+                .filter(e -> e.getKey().toString().startsWith(userId.toString()))  // userId로 시작하는 키 필터링
+                .map(Map.Entry::getValue)  // Map.Entry에서 SseEmitter 값을 추출
+                .findFirst()  // 첫 번째 결과를 찾음
+                .orElse(null);  // 없을 경우 null 반환
+    }
+}

--- a/src/main/java/findme/dangdangcrew/sse/service/SseService.java
+++ b/src/main/java/findme/dangdangcrew/sse/service/SseService.java
@@ -1,9 +1,11 @@
 package findme.dangdangcrew.sse.service;
 
 import findme.dangdangcrew.notification.domain.Notification;
+import findme.dangdangcrew.place.repository.PlaceRepository;
 import findme.dangdangcrew.sse.dto.EventPayload;
 import findme.dangdangcrew.sse.infrastructure.ClockHolder;
 import findme.dangdangcrew.sse.repository.EmitterRepository;
+import findme.dangdangcrew.sse.repository.SseEmitterRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.http.MediaType;
@@ -12,6 +14,7 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.Objects;
 
 @RequiredArgsConstructor
 @Service

--- a/src/main/java/findme/dangdangcrew/sse/service/SseService.java
+++ b/src/main/java/findme/dangdangcrew/sse/service/SseService.java
@@ -1,0 +1,164 @@
+package findme.dangdangcrew.sse.service;
+
+import findme.dangdangcrew.notification.domain.Notification;
+import findme.dangdangcrew.sse.dto.EventPayload;
+import findme.dangdangcrew.sse.infrastructure.ClockHolder;
+import findme.dangdangcrew.sse.repository.EmitterRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.io.IOException;
+import java.util.Map;
+
+@RequiredArgsConstructor
+@Service
+@Log4j2
+public class SseService {
+    private final EmitterRepository emitterRepository;
+    private final ClockHolder clockHolder;
+    private static final long TIMEOUT = 60*1000L;
+    private static final long RECONNECTION_TIMEOUT = 1000L;
+
+
+    public SseEmitter subscribe(Long userId){
+        String eventId = generateEventId(userId);
+
+        SseEmitter sseEmitter = emitterRepository.save(eventId, new SseEmitter(TIMEOUT));
+
+        registerEmitterHandler(eventId, sseEmitter);
+
+        sendToClient(eventId, sseEmitter,"알림 구독 성공 [userId = " + userId +"]");
+
+        // recover 해야하는 상황은 어떤 상황일까?
+        //recoverData(userId, lastEventId, sseEmitter);
+        return sseEmitter;
+    }
+
+    public void broadcast(EventPayload eventPayload){
+        Map<String, SseEmitter> emitters = emitterRepository.findAllEmitters();
+
+        emitters.forEach((k,v)->{
+            try{
+                String eventId = generateEventId(Long.parseLong(k.split("_")[0]));
+                v.send(SseEmitter.event()
+                        .name("broadcast event")
+                        .id(eventId)
+                        .reconnectTime(RECONNECTION_TIMEOUT)
+                        .data(eventPayload, MediaType.APPLICATION_JSON));
+                emitterRepository.saveEvent(eventId, eventPayload);
+                log.info("sent notification, id={}, payload={}, eventId = {}", k, eventPayload, eventId);
+            }catch (IOException e){
+                log.error("fail to send emitter id = {}. {}", k, e.getMessage());
+            }
+        });
+    }
+
+    // 유저가 모임 참가 신청 할때 모임장이 받을 실시간 알림 기능
+    public void sendNotificationToClient(Long userId, Notification notification){
+        SseEmitter sseEmitter = emitterRepository.findEmitterByUserId(userId);
+        if(sseEmitter != null){
+            try {
+                sseEmitter.send(SseEmitter.event()
+                        .name("new-notification")
+                        .data(notification.getMessage()));
+            }catch (IOException e){
+                emitterRepository.deleteAllEmittersStartWithUserId(userId);
+            }
+        }
+    }
+
+    // SseEmitter를 통해 클라이언트에게 이벤트를 전송하는 역할을 합니다.
+    private void sendToClient(String eventId, SseEmitter sseEmitter, Object data){
+        SseEmitter.SseEventBuilder event = getSseEvent(eventId, data);
+        try{
+            sseEmitter.send(event);
+        }catch (IOException e){
+            log.error("구독 실패, eventId ={}, {}", eventId, e.getMessage());
+
+        }
+    }
+
+    // 이벤트 id와, data를 이용해서 SSE 이벤트 객체를 생성합니다.
+    private SseEmitter.SseEventBuilder getSseEvent(String eventId, Object data){
+        return SseEmitter.event()
+                .id(eventId)
+                .data(data)
+                .reconnectTime(RECONNECTION_TIMEOUT);  // 클라이언트와 연결이 끊겼을 때 클라이언트가 서버와 재연결을 시도하기 전에 대기할 시간
+                                                       // 해당 기능은 라이언트가 재연결 시도를 할 수 있도록 브라우저에게 힌트를 주는 역할
+    }
+
+    // SSE 연결이 종료되거나, 타임아웃되거나, 오류가 발생할 때 적절한 처리를 수행하도록 Emitter에 핸들러를 등록
+    private void registerEmitterHandler(String eventId, SseEmitter sseEmitter){
+        /*  SSE 연결이 정상적으로 종료되었을 때
+           - 사용자가 브라우저를 닫거나 SSE 구독을 취소할 때
+           - 서버에서 sseEmitter.complete()을 호출했을 때
+        */
+        sseEmitter.onCompletion(()->{
+            log.info("연결이 끝났습니다. : eventId = {}", eventId);
+            emitterRepository.deleteByEventId(eventId);
+        });
+
+        /*  SSE 연결이 타임아웃되었을 때
+           - 클라이언트가 네트워크 문제로 오랜 시간 동안 응답을 받지 못했을 때
+           - 서버에서 일정 시간 동안 데이터가 전송되지 않아 클라이언트가 반응하지 않을 때
+           - SseEmitter가 설정된 timeout이 초과되었을 때
+        */
+        sseEmitter.onTimeout(()->{
+            log.info("Timeout이 발생했습니다. : eventId={}", eventId);
+            emitterRepository.deleteByEventId(eventId);
+        });
+
+        /*  SSE 연결 중 에러가 발생했을 때
+            - 클라이언트가 갑자기 연결을 끊었을 때 (ERR_INCOMPLETE_CHUNKED_ENCODING)
+            - 서버에서 SSE 메시지를 전송하는 중 네트워크 장애가 발생했을 때
+            - 잘못된 데이터 형식이 전송되어 클라이언트가 파싱하지 못할 때
+         */
+        sseEmitter.onError((e) ->{
+            log.info("에러가 발생했습니다. error={}, eventId={}", e.getMessage(),eventId);
+            emitterRepository.deleteByEventId(eventId);
+        });
+    }
+
+    private String generateEventId(Long userId) {
+        return userId + "_" + clockHolder.mills();
+    }
+
+
+    /** recover 관련 로직 **/
+//    private long extractTimestamp(String eventId) {
+//        try {
+//            return Long.parseLong(eventId.split("_")[1]); // "1_1739162204899" → 1739162204899 변환
+//        } catch (Exception ex) {
+//            log.error("Invalid eventId format: {}", eventId);
+//            return Long.MIN_VALUE;
+//        }
+//    }
+
+    // 당장 recover해야하는 내용이 필요하진 않을 듯 함.
+//    private void recoverData(Long userId, String lastEventId, SseEmitter sseEmitter){
+//        log.info("[recoverData] lastEventId 상태 확인 : {}", lastEventId);
+//        if(lastEventId != null && !lastEventId.trim().isEmpty()){
+//            Map<String,Object> events = emitterRepository.findAllEventStartWithUserId(userId);
+//            log.info("--------------------- 해당 유저에 존재하는 event들 ------------------ ");
+//            for(String eventId : events.keySet()){
+//                log.info(userId + " 번 유저에 저장되어있는 eventId : {}", eventId);
+//            }
+//            log.info("------------------------------------------------------------------");
+//
+//            events.entrySet().stream()
+//                    .filter(e ->  extractTimestamp(lastEventId) < extractTimestamp(e.getKey())) // lastEventId가 e.getKey()보다 작다.
+//                    .forEach(e ->{
+//                        try{
+//                            log.info("recover 된 이벤트 id : {}",e.getKey());
+//                            sendToClient(e.getKey(), sseEmitter, e.getValue());
+//                        }catch (Exception ex){
+//                            log.error("Failed to send event: id={}, error={}", e.getKey(), ex.getMessage());
+//
+//                        }
+//                    });
+//        }
+//    }
+}


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [X] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 문서 수정
- [ ] 코드 리팩토링
- [ ] 테스트 코드 추가 및 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
ex) dev

### 이슈
- closed #18 

### 변경 사항
sse 기능을 추가하였습니다.
1. subscribe api
- userId를 파라미터로 요청을 보내면 해당 id를 기반으로 SseEmitter를 생성해서 클라이언트와의 연결을 관리합니다.
2. broadcast  api
- 시나리오상 로그인 한 유저들에 한에서 인기 장소를 실시간으로 알림 해야 하므로, 연결이 유지되어 SseEmitter를 가지고 있는 유저들에 한에서 실시간 메시지를 보내는 기능입니다.

### 테스트 결과
1. subscribe  이후 1번 유저가 받은 알림
![sseTest1](https://github.com/user-attachments/assets/5fb0288b-dc60-405c-ac86-47f4be0774d3)

2. subscribe 이후 2번 유저가 받은 알림
![sseTest1](https://github.com/user-attachments/assets/07c24445-b40d-437a-88ae-194289b50a94)

### 추가 고민
알림을 보냈는데 연결이 끊겨 못받는 경우를 생각해서 recoverData 메서드를 만들었는데, 알림 기능 중에 연결이 끊겨 다시 받아야 하는 상황에 대해서 시나리오를 그려보지 못해서 일단 주석 처리 하였습니다. 추후에 더 고민 한 후 내용 정리 하겠습니다.  