### PR TITLE
[#20] 채팅방 생성 및 인원 제한 구현

### DIFF
--- a/src/main/java/findme/dangdangcrew/chat/controller/ChatController.java
+++ b/src/main/java/findme/dangdangcrew/chat/controller/ChatController.java
@@ -2,8 +2,10 @@ package findme.dangdangcrew.chat.controller;
 
 import findme.dangdangcrew.chat.dto.ChatMessageRequestDto;
 import findme.dangdangcrew.chat.dto.ChatMessageResponseDto;
+import findme.dangdangcrew.chat.service.ChatRoomService;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import lombok.RequiredArgsConstructor;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.Payload;
@@ -11,9 +13,11 @@ import org.springframework.messaging.handler.annotation.SendTo;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@RequiredArgsConstructor
 public class ChatController {
 
     private final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+    private final ChatRoomService chatRoomService;
 
     @MessageMapping("/chat.sendMessage/{roomId}")
     @SendTo("/subscribe/chatroom/{roomId}")
@@ -35,6 +39,8 @@ public class ChatController {
             @DestinationVariable Long roomId,
             @Payload ChatMessageRequestDto chatMessage) {
 
+        chatRoomService.enterRoom(roomId);
+
         String welcomeMessage = chatMessage.getSender() + "님이 입장하셨습니다.";
         return new ChatMessageResponseDto(
                 String.valueOf(roomId),
@@ -49,6 +55,8 @@ public class ChatController {
     public ChatMessageResponseDto leaveRoom(
             @DestinationVariable Long roomId,
             @Payload ChatMessageRequestDto chatMessage) {
+
+        chatRoomService.leaveRoom(roomId);
 
         String leaveMessage = chatMessage.getSender() + "님이 퇴장하셨습니다.";
         return new ChatMessageResponseDto(

--- a/src/main/java/findme/dangdangcrew/chat/entity/ChatRoom.java
+++ b/src/main/java/findme/dangdangcrew/chat/entity/ChatRoom.java
@@ -25,7 +25,7 @@ public class ChatRoom {
     private Long id;
 
     @OneToOne
-    @JoinColumn(name = "meeting_id", nullable = false)
+    @JoinColumn(name = "meeting_id", nullable = false, unique = true)
     private Meeting meeting;
 
     private static final int MAX_PARTICIPANTS = 20;

--- a/src/main/java/findme/dangdangcrew/chat/entity/ChatRoom.java
+++ b/src/main/java/findme/dangdangcrew/chat/entity/ChatRoom.java
@@ -1,15 +1,16 @@
 package findme.dangdangcrew.chat.entity;
 
+import findme.dangdangcrew.meeting.entity.Meeting;
 import findme.dangdangcrew.user.entity.User;
 import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -23,18 +24,15 @@ public class ChatRoom {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private String title;
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "owner_id", nullable = false)
-    private User owner;
+    @OneToOne
+    @JoinColumn(name = "meeting_id", nullable = false)
+    private Meeting meeting;
 
     private static final int MAX_PARTICIPANTS = 20;
     private int currentParticipants = 0;
 
-    public ChatRoom(User owner, String title) {
-        this.owner = owner;
-        this.title = title;
+    public ChatRoom(Meeting meeting) {
+        this.meeting = meeting;
         this.currentParticipants = 1; // 방장이 자동으로 입장
     }
 

--- a/src/main/java/findme/dangdangcrew/chat/entity/ChatRoom.java
+++ b/src/main/java/findme/dangdangcrew/chat/entity/ChatRoom.java
@@ -1,0 +1,38 @@
+package findme.dangdangcrew.chat.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "chat_room")
+public class ChatRoom {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private static final int MAX_PARTICIPANTS = 20;
+    private int currentParticipants = 0;
+
+    public boolean addParticipant() {
+        if (currentParticipants < MAX_PARTICIPANTS) {
+            currentParticipants++;
+            return true;
+        }
+        return false;
+    }
+
+    public void removeParticipant() {
+        if (currentParticipants > 0) {
+            currentParticipants--;
+        }
+    }
+}

--- a/src/main/java/findme/dangdangcrew/chat/entity/ChatRoom.java
+++ b/src/main/java/findme/dangdangcrew/chat/entity/ChatRoom.java
@@ -1,9 +1,13 @@
 package findme.dangdangcrew.chat.entity;
 
+import findme.dangdangcrew.user.entity.User;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -18,6 +22,12 @@ public class ChatRoom {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    private String title;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "owner_id", nullable = false)
+    private User owner;
 
     private static final int MAX_PARTICIPANTS = 20;
     private int currentParticipants = 0;

--- a/src/main/java/findme/dangdangcrew/chat/entity/ChatRoom.java
+++ b/src/main/java/findme/dangdangcrew/chat/entity/ChatRoom.java
@@ -32,6 +32,12 @@ public class ChatRoom {
     private static final int MAX_PARTICIPANTS = 20;
     private int currentParticipants = 0;
 
+    public ChatRoom(User owner, String title) {
+        this.owner = owner;
+        this.title = title;
+        this.currentParticipants = 1; // 방장이 자동으로 입장
+    }
+
     public boolean addParticipant() {
         if (currentParticipants < MAX_PARTICIPANTS) {
             currentParticipants++;

--- a/src/main/java/findme/dangdangcrew/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/findme/dangdangcrew/chat/repository/ChatRoomRepository.java
@@ -1,0 +1,7 @@
+package findme.dangdangcrew.chat.repository;
+
+import findme.dangdangcrew.chat.entity.ChatRoom;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
+}

--- a/src/main/java/findme/dangdangcrew/chat/service/ChatRoomService.java
+++ b/src/main/java/findme/dangdangcrew/chat/service/ChatRoomService.java
@@ -1,0 +1,30 @@
+package findme.dangdangcrew.chat.service;
+
+import findme.dangdangcrew.chat.entity.ChatRoom;
+import findme.dangdangcrew.chat.repository.ChatRoomRepository;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ChatRoomService {
+
+    private final ChatRoomRepository chatRoomRepository;
+
+    public void enterRoom(Long roomId) {
+        ChatRoom chatRoom = getChatRoom(roomId);
+        if (!chatRoom.addParticipant()) {
+            throw new IllegalStateException("채팅방이 가득 찼습니다. (최대 20명)");
+        }
+    }
+
+    private ChatRoom getChatRoom(Long roomId) {
+        ChatRoom chatRoom = chatRoomRepository.findById(roomId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 채팅방입니다."));
+        return chatRoom;
+    }
+
+}

--- a/src/main/java/findme/dangdangcrew/chat/service/ChatRoomService.java
+++ b/src/main/java/findme/dangdangcrew/chat/service/ChatRoomService.java
@@ -2,7 +2,6 @@ package findme.dangdangcrew.chat.service;
 
 import findme.dangdangcrew.chat.entity.ChatRoom;
 import findme.dangdangcrew.chat.repository.ChatRoomRepository;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -27,4 +26,8 @@ public class ChatRoomService {
         return chatRoom;
     }
 
+    public void leaveRoom(Long roomId) {
+        ChatRoom chatRoom = getChatRoom(roomId);
+        chatRoom.removeParticipant();
+    }
 }

--- a/src/main/java/findme/dangdangcrew/global/config/SecurityConfig.java
+++ b/src/main/java/findme/dangdangcrew/global/config/SecurityConfig.java
@@ -22,7 +22,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(
                                 "/swagger-ui/**", "/v3/api-docs/**", "/swagger-resources/**",
-                                "/api/v1/**"
+                                "/api/v1/**", "/ws/**"
                         ).permitAll()
                         .anyRequest().authenticated()
                 )


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [X] 기능 추가
- [ ] 기능 삭제
- [X] 버그 수정
- [ ] 문서 수정
- [ ] 코드 리팩토링
- [ ] 테스트 코드 추가 및 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
dev

### 이슈
- closed #20 

### 변경 사항
1. ChatRoom 도메인 추가
2. 채팅방 입장, 퇴장 구현
3. WebSocket 연결 시 오류가 생겨 SecurityConfig 수정

### 테스트 결과
MeetingService에서 meeting 생성 시 chatroom도 생성하는 메소드 구현 뒤 입장, 퇴장 테스트 예정
