### PR TITLE
[#23] 이벤트 리스너 클래스 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,12 +38,12 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
-
     // webclient
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
 
     // websocket
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
+
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,6 @@ dependencies {
 
     // websocket
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
-
 }
 
 tasks.named('test') {

--- a/src/main/java/findme/dangdangcrew/DangdangcrewApplication.java
+++ b/src/main/java/findme/dangdangcrew/DangdangcrewApplication.java
@@ -3,9 +3,11 @@ package findme.dangdangcrew;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableAsync;
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableAsync
 public class DangdangcrewApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/findme/dangdangcrew/global/config/SecurityConfig.java
+++ b/src/main/java/findme/dangdangcrew/global/config/SecurityConfig.java
@@ -22,7 +22,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(
                                 "/swagger-ui/**", "/v3/api-docs/**", "/swagger-resources/**",
-                                "/api/v1/**"
+                                "/api/v1/**","/test/**"
                         ).permitAll()
                         .anyRequest().authenticated()
                 )

--- a/src/main/java/findme/dangdangcrew/notification/controller/EventTestController.java
+++ b/src/main/java/findme/dangdangcrew/notification/controller/EventTestController.java
@@ -16,11 +16,25 @@ public class EventTestController {
 
     private final EventPublisher eventPublisher;
 
-    @GetMapping
-    public String testEventApi(){
+    @GetMapping("/apply")
+    public String testApplyApi(){
         eventPublisher.publisher(new ApplyEvent(1L,"강형준",2L,1L,"강남역 카페 모임"));
-        eventPublisher.publisher(new HotPlaceEvent(1L,"강남역 카페","12345"));
-        eventPublisher.publisher(new NewMeetingEvent(1L,"강남역 카페",1L));
+
+        return "ok";
+    }
+
+
+    @GetMapping("/hot-place")
+    public String testHotPlaceApi(){
+        eventPublisher.publisher(new HotPlaceEvent("강남역 카페","12345"));
+
+        return "ok";
+    }
+
+
+    @GetMapping("/new-meeting")
+    public String testNewMeetingApi(){
+        eventPublisher.publisher(new NewMeetingEvent("강남역 카페",1L));
 
         return "ok";
     }

--- a/src/main/java/findme/dangdangcrew/notification/domain/NewMeetingNotification.java
+++ b/src/main/java/findme/dangdangcrew/notification/domain/NewMeetingNotification.java
@@ -11,7 +11,7 @@ public class NewMeetingNotification extends Notification{
     private Long meetingId;
 
     public NewMeetingNotification(Long targetUserId,String message, boolean isRead, Long meetingId, LocalDateTime createdAt){
-        super(null, targetUserId,message,isRead ,NotificationType.MEETING_CREATED, createdAt);
+        super(null, targetUserId, message, isRead , NotificationType.MEETING_CREATED, createdAt);
         this.meetingId = meetingId;
     }
 

--- a/src/main/java/findme/dangdangcrew/notification/event/HotPlaceEvent.java
+++ b/src/main/java/findme/dangdangcrew/notification/event/HotPlaceEvent.java
@@ -4,7 +4,7 @@ package findme.dangdangcrew.notification.event;
  * @param placeName 핫한 장소 이름
  */
 public record HotPlaceEvent(
-        Long targetUserId,
         String placeName,
-        String placeId) {
+        String placeId
+) {
 }

--- a/src/main/java/findme/dangdangcrew/notification/event/NewMeetingEvent.java
+++ b/src/main/java/findme/dangdangcrew/notification/event/NewMeetingEvent.java
@@ -4,8 +4,6 @@ package findme.dangdangcrew.notification.event;
  * @param placeName  즐겨찾기 한 장소 이름
  */
 public record NewMeetingEvent(
-        // targetUserId는 이벤트 리스너에서 추가해야할듯.
-        Long targetUserId,
         String placeName,
         Long meetingId
 ) {

--- a/src/main/java/findme/dangdangcrew/notification/event/NotificationEventListener.java
+++ b/src/main/java/findme/dangdangcrew/notification/event/NotificationEventListener.java
@@ -1,14 +1,19 @@
 package findme.dangdangcrew.notification.event;
 
 import findme.dangdangcrew.notification.domain.ApplyNotification;
+import findme.dangdangcrew.notification.domain.HotPlaceNotification;
 import findme.dangdangcrew.notification.domain.Notification;
 import findme.dangdangcrew.notification.service.NotificationService;
+import findme.dangdangcrew.sse.service.SseService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Component
 @RequiredArgsConstructor
@@ -16,8 +21,9 @@ import java.time.LocalDateTime;
 public class NotificationEventListener {
 
     private final NotificationService notificationService;
+    private final SseService sseService;
 
-    // 이건 즐겨찾기 한 유저 전부에게 뿌려야 하므로 즐겨찾기 유저 찾는 다른 로직이 필요
+//    //이건 즐겨찾기 한 유저 전부에게 뿌려야 하므로 즐겨찾기 유저 찾는 다른 로직이 필요
 //    @EventListener
 //    public void handleNewMeetingNotification(NewMeetingEvent event) {
 //        // 보낼 메세지
@@ -25,6 +31,9 @@ public class NotificationEventListener {
 //
 //        // 생성 시각
 //        LocalDateTime createdAt = LocalDateTime.now();
+//
+//        // 미팅이 생성된 장소에 즐겨찾기 한 유저 조회
+//
 //
 //        // MeetingNotification 생성
 //        Notification notification = new NewMeetingNotification(
@@ -38,30 +47,37 @@ public class NotificationEventListener {
 //        notificationService.saveNotification(notification);
 //    }
 
-    // 이건 연결되어있는 모든 유저한테 보내야 하므로 유저 찾기 로직이 필요
-//    @EventListener
-//    public void handleHotPlaceNotification(HotPlaceEvent event) {
-//        // 보낼 메세지
-//        String message = "[" + event.placeName() + "]" + " 인기 폭발! 많은 사람들이 관심을 가지고 있어요.";
-//
-//        // 생성 시각
-//        LocalDateTime createdAt = LocalDateTime.now();
-//
-//        // MeetingNotification 생성
-//        Notification notification = new HotPlaceNotification(
-//                event.targetUserId(),
-//                message,
-//                false,
-//                event.placeId(),
-//                createdAt
-//        );
-//
-//        notificationService.saveNotification(notification);
-//    }
+    //이건 연결되어있는 모든 유저한테 보내야 하므로 유저 찾기 로직이 필요
+    @EventListener
+    public void handleHotPlaceNotification(HotPlaceEvent event) {
+        // 보낼 메세지
+        String message = "[" + event.placeName() + "]" + " 인기 폭발! 많은 사람들이 관심을 가지고 있어요.";
+
+        // 생성 시각
+        LocalDateTime createdAt = LocalDateTime.now();
+
+        // 현재 연결되어있는 유저들 조회
+        Set<Long> connectUserId = sseService.getConnectedUserIds();
+
+
+        // MeetingNotification 생성
+        List<Notification> notifications = connectUserId.stream()
+                .map(userId -> new HotPlaceNotification(
+                        userId,
+                        message,
+                        false,
+                        event.placeId(),
+                        createdAt
+                )).collect(Collectors.toList());
+
+        notificationService.saveAllNotification(notifications);
+        
+        // 비동기 알림 보내기, 새로운 쓰레드에서는 트랜잭션이 전파되지 않음
+        sseService.broadcastHotPlace(connectUserId, message);
+    }
 
     // 이건 타겟이 단 한명이므로 현상 유지 괜찮을 듯
     @EventListener
-    @Transactional
     public void handleApplyNotification(ApplyEvent event) {
         // 보낼 메세지
         String message = event.nickname() + " 님께서 "+event.meetingName()+ " 에 참여 하고 싶어 합니다.";
@@ -80,5 +96,8 @@ public class NotificationEventListener {
         );
 
         notificationService.saveNotification(notification);
+
+        // 비동기 알림 보내기, 새로운 쓰레드에는 트랜잭션이 전파되지 않음
+        sseService.sendNotificationToClient(event.targetUserId(), message);
     }
 }

--- a/src/main/java/findme/dangdangcrew/notification/service/NotificationService.java
+++ b/src/main/java/findme/dangdangcrew/notification/service/NotificationService.java
@@ -45,4 +45,12 @@ public class NotificationService {
         NotificationEntity notificationEntity = converterFactory.convertToEntity(notification);
         notificationRepository.save(notificationEntity);
     }
+
+    @Transactional
+    public void saveAllNotification(List<Notification> notifications) {
+        List<NotificationEntity> notificationEntities = notifications.stream()
+                .map(converterFactory::convertToEntity)
+                .collect(Collectors.toList());
+        notificationRepository.saveAll(notificationEntities);
+    }
 }

--- a/src/main/java/findme/dangdangcrew/sse/controller/SseController.java
+++ b/src/main/java/findme/dangdangcrew/sse/controller/SseController.java
@@ -1,13 +1,14 @@
 package findme.dangdangcrew.sse.controller;
 
-import findme.dangdangcrew.sse.dto.EventPayload;
 import findme.dangdangcrew.sse.service.SseService;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 @Tag(name = "[SSE] SSE API", description = "사용자에게 실시간으로 알림을 리턴합니다.")
@@ -25,9 +26,10 @@ public class SseController {
         return sseService.subscribe(userId);
     }
 
-    @PostMapping("/broadcast")
-    public ResponseEntity<?> broadcast(@RequestBody EventPayload eventPayload){
-        sseService.broadcast(eventPayload);
-        return ResponseEntity.ok().build();
-    }
+//    @PostMapping("/broadcast")
+//    public ResponseEntity<?> broadcast(@RequestBody EventPayload eventPayload){
+//        sseService.broadcast(eventPayload);
+//        return ResponseEntity.ok().build();
+//    }
+
 }

--- a/src/main/java/findme/dangdangcrew/sse/repository/EmitterRepository.java
+++ b/src/main/java/findme/dangdangcrew/sse/repository/EmitterRepository.java
@@ -2,6 +2,7 @@ package findme.dangdangcrew.sse.repository;
 
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
+import java.util.List;
 import java.util.Map;
 
 public interface EmitterRepository {

--- a/src/main/java/findme/dangdangcrew/sse/service/SseService.java
+++ b/src/main/java/findme/dangdangcrew/sse/service/SseService.java
@@ -23,7 +23,7 @@ public class SseService {
     private static final long RECONNECTION_TIMEOUT = 1000L;
 
 
-    // 알림을 저장하기 위한 연결된 userId 가져오는 로직 
+    // 알림을 저장하기 위한 연결된 userId 가져오는 로직
     public Set<Long> getConnectedUserIds(){
         return emitterRepository.findAllEmitters().keySet().stream()
                 .map(k -> Long.parseLong(k.split("_")[0]))
@@ -89,7 +89,6 @@ public class SseService {
             sseEmitter.send(event);
         }catch (IOException e){
             log.error("구독 실패, eventId ={}, {}", eventId, e.getMessage());
-
         }
     }
 

--- a/src/main/java/findme/dangdangcrew/sse/service/SseService.java
+++ b/src/main/java/findme/dangdangcrew/sse/service/SseService.java
@@ -1,20 +1,17 @@
 package findme.dangdangcrew.sse.service;
 
-import findme.dangdangcrew.notification.domain.Notification;
-import findme.dangdangcrew.place.repository.PlaceRepository;
-import findme.dangdangcrew.sse.dto.EventPayload;
 import findme.dangdangcrew.sse.infrastructure.ClockHolder;
 import findme.dangdangcrew.sse.repository.EmitterRepository;
-import findme.dangdangcrew.sse.repository.SseEmitterRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.http.MediaType;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import java.io.IOException;
-import java.util.Map;
-import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 @Service
@@ -26,7 +23,16 @@ public class SseService {
     private static final long RECONNECTION_TIMEOUT = 1000L;
 
 
+    // 알림을 저장하기 위한 연결된 userId 가져오는 로직 
+    public Set<Long> getConnectedUserIds(){
+        return emitterRepository.findAllEmitters().keySet().stream()
+                .map(k -> Long.parseLong(k.split("_")[0]))
+                .collect(Collectors.toSet());
+    }
+    
     public SseEmitter subscribe(Long userId){
+        // 여러개의 SseEmitter를 관리하기 위해, 중복되지 않은 key값을 생성.
+        // 이를 통해 데이터 복구, 덮어쓰기 방지를 할 수 있다.
         String eventId = generateEventId(userId);
 
         SseEmitter sseEmitter = emitterRepository.save(eventId, new SseEmitter(TIMEOUT));
@@ -40,33 +46,36 @@ public class SseService {
         return sseEmitter;
     }
 
-    public void broadcast(EventPayload eventPayload){
-        Map<String, SseEmitter> emitters = emitterRepository.findAllEmitters();
-
-        emitters.forEach((k,v)->{
-            try{
-                String eventId = generateEventId(Long.parseLong(k.split("_")[0]));
-                v.send(SseEmitter.event()
-                        .name("broadcast event")
-                        .id(eventId)
-                        .reconnectTime(RECONNECTION_TIMEOUT)
-                        .data(eventPayload, MediaType.APPLICATION_JSON));
-                emitterRepository.saveEvent(eventId, eventPayload);
-                log.info("sent notification, id={}, payload={}, eventId = {}", k, eventPayload, eventId);
-            }catch (IOException e){
-                log.error("fail to send emitter id = {}. {}", k, e.getMessage());
+    // 실시간 인기 장소 알림 비동기 처리
+    @Async
+    public void broadcastHotPlace(Set<Long> connectedUserIds, String message){
+        connectedUserIds.forEach(userId -> {
+            SseEmitter emitter = emitterRepository.findEmitterByUserId(userId);
+            if (emitter != null) {
+                try {
+                    String eventId = generateEventId(userId);
+                    emitter.send(SseEmitter.event()
+                            .name("broadcast event")
+                            .id(eventId)
+                            .reconnectTime(RECONNECTION_TIMEOUT)
+                            .data(message, MediaType.APPLICATION_JSON));
+                    log.info("sent notification to userId={}, payload={}", userId, message);
+                } catch (IOException e) {
+                    log.error("fail to send emitter to userId={} - {}", userId, e.getMessage());
+                }
             }
         });
     }
 
-    // 유저가 모임 참가 신청 할때 모임장이 받을 실시간 알림 기능
-    public void sendNotificationToClient(Long userId, Notification notification){
+    // 유저가 모임 참가 신청 할때 모임장이 받을 실시간 알림
+    @Async
+    public void sendNotificationToClient(Long userId, String message){
         SseEmitter sseEmitter = emitterRepository.findEmitterByUserId(userId);
         if(sseEmitter != null){
             try {
                 sseEmitter.send(SseEmitter.event()
-                        .name("new-notification")
-                        .data(notification.getMessage()));
+                        .name("apply-notification")
+                        .data(message));
             }catch (IOException e){
                 emitterRepository.deleteAllEmittersStartWithUserId(userId);
             }

--- a/src/main/java/findme/dangdangcrew/sse/service/SseService.java
+++ b/src/main/java/findme/dangdangcrew/sse/service/SseService.java
@@ -49,6 +49,7 @@ public class SseService {
     // 실시간 인기 장소 알림 비동기 처리
     @Async
     public void broadcastHotPlace(Set<Long> connectedUserIds, String message){
+        log.info("[broadcastHotPlace] 실행 쓰레드 : {}",Thread.currentThread().getName());
         connectedUserIds.forEach(userId -> {
             SseEmitter emitter = emitterRepository.findEmitterByUserId(userId);
             if (emitter != null) {


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 문서 수정
- [x] 코드 리팩토링
- [ ] 테스트 코드 추가 및 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
dev

### 이슈
- closed #23 

### 변경 사항
1. HotPlaceEvent, NewMeetingEvent 객체 수정
- 해당 이벤트 객체들은 이벤트를 발행하는 도메인에서 타겟 유저를 특정 할 수 없기 때문에 targetUserId 필드를 제외 하였습니다.

2. NotificationEventListener 클래스 수정
- handleHotPlaceNotification 메서드에서 현재 연결되어있는 유저들을 조회해서 해당 유저들이 받을 알림을 생성 및 저장하고, 알림을 보냅니다.
- handleApplyNotification 메서드에서  알림을 생성하고 알림을 보냅니다.

3. SseService 클래스 수정
- broadcast 메서드를 삭제하고, broadcastHotPlace, sendNotificationToClient 를 추가
- 비동기로 broadcastHotPlace 메서드를 추가 하였습니다. 이전 broadcast 메서드와 기능이 동일합니다. 
- 비동기로 sendNotificationToClient 메서드를 추가 하였습니다. 

4. 비동기로 처리한 이유
- 서버가 동시 sse 요청을 처리할 때 속도가 빨라짐
- 알림 전송을 기다릴 필요 없이 즉시 응답 가능
- 실시간 알림 전송이 완벽한 정확성이 요구되지 않는다는 생각

### 테스트 결과
1. 연결된 1번, 2번 유저에게 핫플레이스 알림 테스트 결과
<img width="503" alt="1" src="https://github.com/user-attachments/assets/72ce97d7-8e83-4f2f-ba87-b1db6c465cad" />

<img width="506" alt="2" src="https://github.com/user-attachments/assets/a0ad64d0-2f96-4523-a186-5a6247ee279a" />

2. 모임장 에게 참가 신청 알림 테스트 결과
<img width="497" alt="3" src="https://github.com/user-attachments/assets/69b5d860-c2dc-4998-8afe-407bc46e961f" />




