### PR TITLE
[#34] ExceptionHandler 클래스 추가, 공통 ResponseDto 추가

### DIFF
--- a/src/main/java/findme/dangdangcrew/global/dto/ResponseDto.java
+++ b/src/main/java/findme/dangdangcrew/global/dto/ResponseDto.java
@@ -1,0 +1,12 @@
+package findme.dangdangcrew.global.dto;
+
+import lombok.Builder;
+
+public record ResponseDto<T>(
+        T data,
+        String msg
+) {
+    public static <T> ResponseDto<T> of(T data, String msg){
+        return new ResponseDto<>(data,msg);
+    }
+}

--- a/src/main/java/findme/dangdangcrew/global/exception/CustomException.java
+++ b/src/main/java/findme/dangdangcrew/global/exception/CustomException.java
@@ -1,0 +1,12 @@
+package findme.dangdangcrew.global.exception;
+
+import lombok.Getter;
+
+@Getter
+public class CustomException extends RuntimeException{
+    private ErrorCode errorCode;
+    public CustomException(ErrorCode errorCode){
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/findme/dangdangcrew/global/exception/ErrorCode.java
+++ b/src/main/java/findme/dangdangcrew/global/exception/ErrorCode.java
@@ -19,11 +19,13 @@ public enum ErrorCode {
 
     // Notification Error
     NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND,"존재하지 않는 알림입니다."),
-    INVALID_NOTIFICATION_TYPE(HttpStatus.BAD_REQUEST, "지원되지 않는 알림 타입입니다.")
+    INVALID_NOTIFICATION_TYPE(HttpStatus.BAD_REQUEST, "지원되지 않는 알림 타입입니다."),
+
+    // Invalidation Error
+    INVALID_PARAMETER(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
+    INVALID_JSON_FORMAT(HttpStatus.BAD_REQUEST, "요청한 JSON 형식이 올바르지 않습니다."),
+
     ;
-
-
-
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/findme/dangdangcrew/global/exception/ErrorCode.java
+++ b/src/main/java/findme/dangdangcrew/global/exception/ErrorCode.java
@@ -1,0 +1,30 @@
+package findme.dangdangcrew.global.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+    // User Error
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 유저입니다."),
+
+    // FavoritePlace Error
+    ALREADY_FAVORITE_PLACE(HttpStatus.BAD_REQUEST, "이미 즐겨찾기한 장소입니다."),
+
+    // Kakao Map API Error
+    DOCUMENTS_NOT_FOUND(HttpStatus.BAD_REQUEST, "Kakao API 응답에서 'documents' 필드를 찾을 수 없습니다."),
+    INVALID_DATA_TYPE(HttpStatus.BAD_REQUEST,"Kakao API 응답 데이터 형식이 잘못되었습니다."),
+
+    // Notification Error
+    NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND,"존재하지 않는 알림입니다."),
+    INVALID_NOTIFICATION_TYPE(HttpStatus.BAD_REQUEST, "지원되지 않는 알림 타입입니다.")
+    ;
+
+
+
+
+    private final HttpStatus status;
+    private final String message;
+}

--- a/src/main/java/findme/dangdangcrew/global/exception/ErrorResponseDto.java
+++ b/src/main/java/findme/dangdangcrew/global/exception/ErrorResponseDto.java
@@ -1,0 +1,48 @@
+package findme.dangdangcrew.global.exception;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Path;
+import lombok.Builder;
+import org.springframework.http.HttpStatus;
+import org.springframework.validation.FieldError;
+
+import java.util.List;
+import java.util.Optional;
+
+@Builder
+public record ErrorResponseDto(
+        HttpStatus code,
+        String message,
+        @JsonInclude(JsonInclude.Include.NON_EMPTY) // errors가 비어있으면 JSON 응답에서 제외
+        List<ValidationError> validationErrors
+) {
+    public static ErrorResponseDto of(ErrorCode errorCode, List<ValidationError> validationErrors){
+        return ErrorResponseDto.builder()
+                .code(errorCode.getStatus())
+                .message(errorCode.getMessage())
+                .validationErrors(Optional.ofNullable(validationErrors).orElse(List.of())) // null 방지
+                .build();
+    }
+    public static ErrorResponseDto of(HttpStatus status, String errorMessage){
+        return ErrorResponseDto.builder()
+                .code(status)
+                .message(errorMessage)
+                .build();
+    }
+    public record ValidationError(String field, String message) {
+        public static ValidationError of(final FieldError fieldError) {
+            return new ValidationError(fieldError.getField(), fieldError.getDefaultMessage());
+        }
+        public static ValidationError of(final ConstraintViolation<?> constraintViolation){
+            return new ValidationError(
+                    extractFieldName(constraintViolation.getPropertyPath()), // 필드명만 추출
+                    constraintViolation.getMessage()
+            );
+        }
+        private static String extractFieldName(Path propertyPath) {
+            String[] pathElements = propertyPath.toString().split("\\.");
+            return pathElements[pathElements.length - 1]; // 마지막 요소가 필드명
+        }
+    }
+}

--- a/src/main/java/findme/dangdangcrew/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/findme/dangdangcrew/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,47 @@
+package findme.dangdangcrew.global.exception;
+
+import findme.dangdangcrew.global.dto.ResponseDto;
+import io.swagger.v3.oas.annotations.Hidden;
+import jakarta.validation.ConstraintViolationException;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Log4j2
+@Hidden
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<ResponseDto<?>> handleConstraintViolationException(ConstraintViolationException ex){
+        log.error("유효성 검사 예외 발생 msg:{}",ex.getMessage());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ResponseDto.of(HttpStatus.BAD_REQUEST,  ex.getMessage()));
+    }
+
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<ResponseDto<?>> CustomException(CustomException ex){
+        log.error("예외 발생 msg:{}",ex.getErrorCode().getMessage());
+        return ResponseEntity.status(ex.getErrorCode().getStatus()).body(ResponseDto.of(ex.getErrorCode().getStatus(), ex.getErrorCode().getMessage()));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ResponseDto<?>> handleMethodArgumentNotValidException(MethodArgumentNotValidException ex){
+        BindingResult bindingResult = ex.getBindingResult();
+        FieldError fieldError = bindingResult.getFieldError();
+        String message = fieldError.getDefaultMessage();
+        log.error("유효성 검사 예외 발생 msg:{}",message);
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ResponseDto.of(HttpStatus.BAD_REQUEST, message));
+    }
+
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<ResponseDto<?>> handleHttpMessageNotReadableException(HttpMessageNotReadableException ex) {
+        String errorMessage = "요청한 JSON 데이터를 읽을 수 없습니다: " + ex.getMessage();
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ResponseDto.of(HttpStatus.BAD_REQUEST, errorMessage));
+    }
+}

--- a/src/main/java/findme/dangdangcrew/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/findme/dangdangcrew/global/exception/GlobalExceptionHandler.java
@@ -1,47 +1,75 @@
 package findme.dangdangcrew.global.exception;
 
-import findme.dangdangcrew.global.dto.ResponseDto;
 import io.swagger.v3.oas.annotations.Hidden;
+import jakarta.validation.ConstraintViolation;
 import jakarta.validation.ConstraintViolationException;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.validation.BindingResult;
-import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Log4j2
 @Hidden
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
+    // @RequestParam, @PathVariable의 유효성 검사를 수행
     @ExceptionHandler(ConstraintViolationException.class)
-    public ResponseEntity<ResponseDto<?>> handleConstraintViolationException(ConstraintViolationException ex){
-        log.error("유효성 검사 예외 발생 msg:{}",ex.getMessage());
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ResponseDto.of(HttpStatus.BAD_REQUEST,  ex.getMessage()));
+    public ResponseEntity<ErrorResponseDto> handleConstraintViolationException(ConstraintViolationException ex){
+        log.error("[Validated] 유효성 검사 예외 발생 msg:{}",ex.getMessage());
+        ErrorCode errorCode = ErrorCode.INVALID_PARAMETER;
+        List<ErrorResponseDto.ValidationError> validationErrors = extractValidationErrors(ex.getConstraintViolations());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ErrorResponseDto.of(errorCode, validationErrors));
     }
 
+    // 커스템 예외를 검사를 수행
     @ExceptionHandler(CustomException.class)
-    public ResponseEntity<ResponseDto<?>> CustomException(CustomException ex){
+    public ResponseEntity<ErrorResponseDto> customException(CustomException ex){
         log.error("예외 발생 msg:{}",ex.getErrorCode().getMessage());
-        return ResponseEntity.status(ex.getErrorCode().getStatus()).body(ResponseDto.of(ex.getErrorCode().getStatus(), ex.getErrorCode().getMessage()));
+        ErrorCode errorCode = ex.getErrorCode();
+        HttpStatus status = errorCode.getStatus();
+        String errorMessage = errorCode.getMessage();
+        return ResponseEntity.status(errorCode.getStatus()).body(ErrorResponseDto.of(status, errorMessage));
     }
 
+    //  JSON 데이터를 DTO로 변환하는 과정에서 유효성 검사를 수행
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<ResponseDto<?>> handleMethodArgumentNotValidException(MethodArgumentNotValidException ex){
-        BindingResult bindingResult = ex.getBindingResult();
-        FieldError fieldError = bindingResult.getFieldError();
-        String message = fieldError.getDefaultMessage();
-        log.error("유효성 검사 예외 발생 msg:{}",message);
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ResponseDto.of(HttpStatus.BAD_REQUEST, message));
+    public ResponseEntity<ErrorResponseDto> handleMethodArgumentNotValidException(MethodArgumentNotValidException ex){
+        ErrorCode errorCode = ErrorCode.INVALID_PARAMETER;
+        List<ErrorResponseDto.ValidationError> validationErrors = extractValidationErrors(ex.getBindingResult());
+        log.error("[Valid] 유효성 검사 예외 발생 errors: {}", validationErrors);
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ErrorResponseDto.of(errorCode, validationErrors));
+    }
+    
+    // json 형식 검사를 수행
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<ErrorResponseDto> handleHttpMessageNotReadableException(HttpMessageNotReadableException ex) {
+        ErrorCode errorCode = ErrorCode.INVALID_JSON_FORMAT;
+        String errorMessage = errorCode.getMessage() + " : " + ex.getMessage();
+        HttpStatus status = errorCode.getStatus();
+        log.error("예외 발생 msg: {}", errorMessage);
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ErrorResponseDto.of(status, errorMessage));
     }
 
-    @ExceptionHandler(HttpMessageNotReadableException.class)
-    public ResponseEntity<ResponseDto<?>> handleHttpMessageNotReadableException(HttpMessageNotReadableException ex) {
-        String errorMessage = "요청한 JSON 데이터를 읽을 수 없습니다: " + ex.getMessage();
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ResponseDto.of(HttpStatus.BAD_REQUEST, errorMessage));
+    private List<ErrorResponseDto.ValidationError> extractValidationErrors(BindingResult bindingResult) {
+        return bindingResult.getFieldErrors()
+                .stream()
+                .map(ErrorResponseDto.ValidationError::of)
+                .collect(Collectors.toList());
+    }
+
+    private List<ErrorResponseDto.ValidationError> extractValidationErrors(Set<ConstraintViolation<?>> constraintViolations) {
+        return constraintViolations
+                .stream()
+                .map(ErrorResponseDto.ValidationError::of)
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/findme/dangdangcrew/notification/controller/NotificationController.java
+++ b/src/main/java/findme/dangdangcrew/notification/controller/NotificationController.java
@@ -1,5 +1,6 @@
 package findme.dangdangcrew.notification.controller;
 
+import findme.dangdangcrew.global.dto.ResponseDto;
 import findme.dangdangcrew.notification.domain.Notification;
 import findme.dangdangcrew.notification.service.NotificationService;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -20,16 +21,19 @@ public class NotificationController {
     // 사용자의 모든 알림 조회 API
     // 토큰 기능 추가 이후 변경될 기능입니다.
     @GetMapping("/{userId}")
-    public ResponseEntity<List<Notification>> getUserNotifications(@PathVariable("userId") Long userId){
+    public ResponseEntity<ResponseDto<List<Notification>>> getUserNotifications(@PathVariable("userId") Long userId){
         List<Notification> userNotifications = notificationService.getUserNotifications(userId);
 
-        return ResponseEntity.ok(userNotifications);
+        return ResponseEntity.ok(ResponseDto.of(
+                userNotifications,
+                "유저의 알림을 성공적으로 조회하였습니다."));
     }
 
     // 특정 알림을 읽음 처리
     @PatchMapping("/{notificationId}/read")
-    public ResponseEntity<String> readNotification(@PathVariable("notificationId") Long notificationId) {
+    public ResponseEntity<ResponseDto> readNotification(@PathVariable("notificationId") Long notificationId) {
         Long readNotificationId = notificationService.readNotification(notificationId);
-        return ResponseEntity.ok(readNotificationId + "번 알림이 읽음 처리되었습니다.");
+        String message = readNotificationId + "번 알림이 읽음 처리되었습니다.";
+        return ResponseEntity.ok(ResponseDto.of(null, message));
     }
 }

--- a/src/main/java/findme/dangdangcrew/notification/converter/NotificationConverterFactory.java
+++ b/src/main/java/findme/dangdangcrew/notification/converter/NotificationConverterFactory.java
@@ -1,5 +1,7 @@
 package findme.dangdangcrew.notification.converter;
 
+import findme.dangdangcrew.global.exception.CustomException;
+import findme.dangdangcrew.global.exception.ErrorCode;
 import findme.dangdangcrew.notification.domain.Notification;
 import findme.dangdangcrew.notification.domain.NotificationEntity;
 import org.springframework.stereotype.Component;
@@ -22,7 +24,7 @@ public class NotificationConverterFactory {
         return converters.stream()
                 .filter(converter -> converter.canConvert(notificationEntity))
                 .findFirst()
-                .orElseThrow(() -> new IllegalArgumentException("지원되지 않는 알림 타입입니다."))
+                .orElseThrow(() -> new CustomException(ErrorCode.INVALID_NOTIFICATION_TYPE))
                 .convert(notificationEntity);
     }
 
@@ -30,7 +32,7 @@ public class NotificationConverterFactory {
         return converters.stream()
                 .filter(converters -> converters.canConvertToEntity(notification))
                 .findFirst()
-                .orElseThrow(() -> new IllegalArgumentException("지원되지 않는 알림 타입입니다."))
+                .orElseThrow(() -> new CustomException(ErrorCode.INVALID_NOTIFICATION_TYPE))
                 .convertToEntity(notification);
     }
 

--- a/src/main/java/findme/dangdangcrew/notification/service/NotificationService.java
+++ b/src/main/java/findme/dangdangcrew/notification/service/NotificationService.java
@@ -1,5 +1,7 @@
 package findme.dangdangcrew.notification.service;
 
+import findme.dangdangcrew.global.exception.CustomException;
+import findme.dangdangcrew.global.exception.ErrorCode;
 import findme.dangdangcrew.notification.converter.NotificationConverterFactory;
 import findme.dangdangcrew.notification.domain.Notification;
 import findme.dangdangcrew.notification.domain.NotificationEntity;
@@ -33,7 +35,7 @@ public class NotificationService {
     @Transactional
     public Long readNotification(Long notificationId){
         NotificationEntity entity = notificationRepository.findById(notificationId)
-                .orElseThrow(() -> new IllegalArgumentException("해당 알림이 존재하지 않습니다."));
+                .orElseThrow(() -> new CustomException(ErrorCode.NOTIFICATION_NOT_FOUND));
 
         entity.markAsRead();
         return entity.getId();

--- a/src/main/java/findme/dangdangcrew/place/controller/FavoritePlaceController.java
+++ b/src/main/java/findme/dangdangcrew/place/controller/FavoritePlaceController.java
@@ -1,6 +1,7 @@
 package findme.dangdangcrew.place.controller;
 
 
+import findme.dangdangcrew.global.dto.ResponseDto;
 import findme.dangdangcrew.place.dto.FavoritePlaceResponseDto;
 import findme.dangdangcrew.place.dto.PlaceRequestDto;
 import findme.dangdangcrew.place.service.FavoritePlaceService;
@@ -20,15 +21,20 @@ public class FavoritePlaceController {
     private final FavoritePlaceService favoritePlaceService;
 
     @PostMapping
-    public ResponseEntity<String> registerFavoritePlace(@RequestParam("userId") Long userId,
+    public ResponseEntity<ResponseDto> registerFavoritePlace(@RequestParam("userId") Long userId,
                                                 @RequestBody PlaceRequestDto placeRequestDto){
-        String message = favoritePlaceService.registerFavoritePlace(userId, placeRequestDto);
-        return ResponseEntity.ok(userId + "번 유저가 " + message + " 장소를 즐겨찾기 하였습니다.");
+        String placeName = favoritePlaceService.registerFavoritePlace(userId, placeRequestDto);
+        String message = userId + "번 유저가 " + placeName + " 장소를 즐겨찾기 하였습니다.";
+
+        return ResponseEntity.ok(ResponseDto.of(null, message));
     }
 
     @GetMapping
-    public ResponseEntity<List<FavoritePlaceResponseDto>> getAllFavoritePlace(@RequestParam("userId") Long userId){
+    public ResponseEntity<ResponseDto<List<FavoritePlaceResponseDto>>> getAllFavoritePlace(@RequestParam("userId") Long userId){
         List<FavoritePlaceResponseDto> favoritePlaceResponseDtos = favoritePlaceService.getAllFavoritePlace(userId);
-        return ResponseEntity.ok(favoritePlaceResponseDtos);
+        return ResponseEntity.ok(ResponseDto.of(
+                favoritePlaceResponseDtos,
+                "유저가 즐겨찾기한 장소를 성공적으로 조회하였습니다."
+                ));
     }
 }

--- a/src/main/java/findme/dangdangcrew/place/service/FavoritePlaceService.java
+++ b/src/main/java/findme/dangdangcrew/place/service/FavoritePlaceService.java
@@ -1,5 +1,7 @@
 package findme.dangdangcrew.place.service;
 
+import findme.dangdangcrew.global.exception.CustomException;
+import findme.dangdangcrew.global.exception.ErrorCode;
 import findme.dangdangcrew.place.domain.FavoritePlace;
 import findme.dangdangcrew.place.domain.Place;
 import findme.dangdangcrew.place.dto.FavoritePlaceResponseDto;
@@ -27,13 +29,13 @@ public class FavoritePlaceService {
     @Transactional
     public String registerFavoritePlace(Long userId, PlaceRequestDto placeRequestDto){
         User user = userRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
+                .orElseThrow(()-> new CustomException(ErrorCode.USER_NOT_FOUND));
 
         Place place = placeService.findOrCreatePlace(placeRequestDto);
 
         if(favoritePlaceRepository.existsByUserAndPlace(user,place)){
             log.info("이미 즐겨찾기한 장소입니다. - userId: {}, placeId: {}", user.getId(), place.getId());
-            throw new IllegalStateException("이미 즐겨찾기한 장소입니다.");
+            throw new CustomException(ErrorCode.ALREADY_FAVORITE_PLACE);
         }
 
         FavoritePlace favoritePlace = FavoritePlace.builder()
@@ -48,7 +50,7 @@ public class FavoritePlaceService {
     }
 
     public List<FavoritePlaceResponseDto> getAllFavoritePlace(Long userId) {
-        User user = userRepository.findById(userId).orElseThrow(()->new IllegalArgumentException("유저가 존재하지 않습니다."));
+        User user = userRepository.findById(userId).orElseThrow(()->new CustomException(ErrorCode.USER_NOT_FOUND));
         List<FavoritePlace> favoritePlaces = favoritePlaceRepository.findAllWithPlaceByUser(user);
 
         return favoritePlaces.stream()

--- a/src/main/java/findme/dangdangcrew/place/service/PlaceService.java
+++ b/src/main/java/findme/dangdangcrew/place/service/PlaceService.java
@@ -1,5 +1,7 @@
 package findme.dangdangcrew.place.service;
 
+import findme.dangdangcrew.global.exception.CustomException;
+import findme.dangdangcrew.global.exception.ErrorCode;
 import findme.dangdangcrew.place.domain.Place;
 import findme.dangdangcrew.place.dto.PlaceRequestDto;
 import findme.dangdangcrew.place.dto.PlaceResponseDto;
@@ -77,13 +79,13 @@ public class PlaceService {
      */
     private List<Map<String, Object>> extractDocuments(Map<String, Object> kakaoResponse) {
         if (kakaoResponse == null || !kakaoResponse.containsKey("documents")) {
-            throw new IllegalArgumentException("Kakao API 응답에서 'documents' 필드를 찾을 수 없습니다.");
+            throw new CustomException(ErrorCode.DOCUMENTS_NOT_FOUND);
         }
 
         Object documentsObj = kakaoResponse.get("documents");
 
         if (!(documentsObj instanceof List<?> documents) || documents.isEmpty()) {
-            throw new IllegalArgumentException("Kakao API 응답에서 유효한 장소 정보가 없습니다.");
+            throw new CustomException(ErrorCode.INVALID_DATA_TYPE);
         }
 
         return (List<Map<String, Object>>) documents;
@@ -96,7 +98,7 @@ public class PlaceService {
         Object firstItem = documents.get(0);
 
         if (!(firstItem instanceof Map<?, ?> placeData)) {
-            throw new IllegalArgumentException("Kakao API 응답 데이터 구조가 예상과 다릅니다.");
+            throw new CustomException(ErrorCode.INVALID_DATA_TYPE);
         }
 
         return (Map<String, Object>) placeData;

--- a/src/main/java/findme/dangdangcrew/user/controller/UserController.java
+++ b/src/main/java/findme/dangdangcrew/user/controller/UserController.java
@@ -10,10 +10,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("api/v1/users")

--- a/src/main/java/findme/dangdangcrew/user/controller/UserController.java
+++ b/src/main/java/findme/dangdangcrew/user/controller/UserController.java
@@ -6,12 +6,14 @@ import findme.dangdangcrew.user.dto.UserRequestDto;
 import findme.dangdangcrew.user.dto.UserResponseDto;
 import findme.dangdangcrew.user.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("api/v1/users")
@@ -33,5 +35,4 @@ public class UserController {
     public ResponseEntity<TokenResponseDto> login(@RequestBody LoginRequestDto request) {
         return ResponseEntity.ok(userService.authenticate(request));
     }
-
 }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 문서 수정
- [ ] 코드 리팩토링
- [ ] 테스트 코드 추가 및 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
dev

### 이슈
- closed #34 

### 변경 사항
1. 예외처리 핸들러 클래스를 추가 하였습니다.
- 현재 @RestControllerAdvice 어노테이션이 살아있으면 swagger 접속시 403 뜨는 에러가 있습니다. 일단 @Hidden 어노테이션을 이용하고, 이후에 수정을 해 보겠습니다.

2. 공통 ResponseDto 클래스를 추가 하였습니다.
- 공통 ResponseDto 는 최종 응답을 리턴 할 때, 응답에 대한 메시지와 응답 데이터를 규격에 맞추어 공통되게 리턴하기 위한 객체입니다. 

*추가사항*
유효성 검사 예외가 발생 할 시, 여러 에러가 발생 할 수 있습니다.
 예) 잘못된 email 형식, 잘못된 phone_number 형식 등
 해당 예외 들을 클라이언트에게 전달하기 위해, ValidationError 를 리스트 형식으로 리턴하는 방식으로 수정 하였습니다.



### 테스트 결과
![image](https://github.com/user-attachments/assets/6ee1bfc0-8492-4408-bc88-0f35da679d67)

<img width="400" alt="image" src="https://github.com/user-attachments/assets/5506ba3d-7e80-4ac1-9497-4c1d6fa07c7c" />


