### PR TITLE
[#40] logout API

### DIFF
--- a/src/main/java/findme/dangdangcrew/global/config/JwtTokenProvider.java
+++ b/src/main/java/findme/dangdangcrew/global/config/JwtTokenProvider.java
@@ -51,7 +51,7 @@ public class JwtTokenProvider {
         return Jwts.parserBuilder()
                 .setSigningKey(key)
                 .build()
-                .parseClaimsJws(token)
+                .parseClaimsJws(token.trim())
                 .getBody()
                 .getSubject();
     }

--- a/src/main/java/findme/dangdangcrew/global/config/SecurityConfig.java
+++ b/src/main/java/findme/dangdangcrew/global/config/SecurityConfig.java
@@ -24,6 +24,7 @@ public class SecurityConfig {
                                 "/swagger-ui/**", "/v3/api-docs/**", "/swagger-resources/**",
                                 "/api/v1/**", "/ws/**","/test/**"
                         ).permitAll()
+                        .requestMatchers("/api/v1/users/logout").authenticated()
                         .anyRequest().authenticated()
                 )
                 .formLogin(AbstractHttpConfigurer::disable);

--- a/src/main/java/findme/dangdangcrew/global/config/SwaggerConfig.java
+++ b/src/main/java/findme/dangdangcrew/global/config/SwaggerConfig.java
@@ -3,6 +3,7 @@ package findme.dangdangcrew.global.config;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.servers.Server;
 import org.springframework.context.annotation.Bean;
@@ -15,9 +16,10 @@ import java.util.List;
 public class SwaggerConfig {
 
     @Bean
-    public OpenAPI openAPI(){
+    public OpenAPI openAPI() {
         return new OpenAPI()
-                .components(new Components())
+                .components(new Components().addSecuritySchemes("BearerAuth", securityScheme()))
+                .addSecurityItem(new SecurityRequirement().addList("BearerAuth"))
                 .info(apiInfo())
                 .servers(servers());
     }

--- a/src/main/java/findme/dangdangcrew/user/controller/UserController.java
+++ b/src/main/java/findme/dangdangcrew/user/controller/UserController.java
@@ -7,6 +7,9 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -16,6 +19,7 @@ import org.springframework.web.bind.annotation.*;
 @Tag(name = "User API", description = "사용자 관련 API")
 public class UserController {
 
+    private static final Logger logger = LoggerFactory.getLogger(UserController.class); // ✅ Logger 선언 추가
     private final UserService userService;
 
     @PostMapping("/signup")
@@ -37,5 +41,21 @@ public class UserController {
         TokenResponseDto response = userService.refreshAccessToken(request);
         return ResponseEntity.ok(response);
     }
+
+    @PostMapping("/logout")
+    @Operation(summary = "로그아웃", description = "로그아웃을 수행하고 Refresh Token을 삭제합니다.")
+    public ResponseEntity<Void> logout(@RequestHeader(value = "authorization", required = false) String token) {
+        logger.info("🚀 Received Authorization Header: {}", token);
+
+        if (token == null || !token.startsWith("Bearer ")) {
+            logger.error("❌ Missing or invalid Authorization header");
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(null);
+        }
+
+        String accessToken = token.substring(7).trim();
+        userService.logout(accessToken);
+        return ResponseEntity.noContent().build();
+    }
+
 
 }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [X] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 문서 수정
- [ ] 코드 리팩토링
- [ ] 테스트 코드 추가 및 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
dev

### 이슈
[#40 ]
### 변경 사항
1. 스웨거에 Authorize 버튼 추가
2. 토큰 공백 제거 추가
3. 로그아웃 api 접근 시 인증(로그인)필요하도록 설정
4. 로그아웃 api 추가

### 테스트 결과
1. 로그인 후 엑세스 토큰 획득
![스크린샷 2025-02-12 오후 4 25 35](https://github.com/user-attachments/assets/59db3d56-7c33-41c2-ba35-d1ce77258ac3)

2. 스웨거 우측 상단 Authorize 클릭 후 엑세스 토큰 등록
(스웨거는 자동으로 Bearer를 붙이므로, JWT 토큰만
![스크린샷 2025-02-12 오후 4 25 23](https://github.com/user-attachments/assets/500c0d22-bb8e-4c68-8366-35ecf4cd5290)
 입력)

3. 로그아웃 api 실행 (Authorize에 엑세스 토큰 등록했으므로 아무것도 입력하지 않아도 됨)
![스크린샷 2025-02-12 오후 4 25 13](https://github.com/user-attachments/assets/cbafae24-e47c-4ec8-84f3-d20b735a92b2)

