### PR TITLE
[#42] NewMeeting 이벤트 관련 로직 수정

### DIFF
--- a/src/main/java/findme/dangdangcrew/meeting/service/MeetingService.java
+++ b/src/main/java/findme/dangdangcrew/meeting/service/MeetingService.java
@@ -11,6 +11,7 @@ import findme.dangdangcrew.meeting.entity.enums.UserMeetingStatus;
 import findme.dangdangcrew.meeting.mapper.MeetingMapper;
 import findme.dangdangcrew.meeting.repository.MeetingRepository;
 import findme.dangdangcrew.notification.event.ApplyEvent;
+import findme.dangdangcrew.notification.event.NewMeetingEvent;
 import findme.dangdangcrew.place.domain.Place;
 import findme.dangdangcrew.place.service.PlaceService;
 import findme.dangdangcrew.user.entity.User;
@@ -60,6 +61,7 @@ public class MeetingService {
         Meeting meeting = meetingMapper.toEntity(meetingRequestDto, place);
         meeting = meetingRepository.save(meeting);
         chatRoomService.createChatRoom(meeting);
+        eventPublisher.publisher(new NewMeetingEvent(place.getPlaceName(),meeting.getId(),place.getId()));
 
         User user = userRepository.findById(userId).orElseThrow();
         UserMeeting userMeeting = userMeetingService.saveUserAndMeeting(meeting, user, UserMeetingStatus.LEADER);

--- a/src/main/java/findme/dangdangcrew/notification/controller/EventTestController.java
+++ b/src/main/java/findme/dangdangcrew/notification/controller/EventTestController.java
@@ -34,7 +34,7 @@ public class EventTestController {
 
     @GetMapping("/new-meeting")
     public String testNewMeetingApi(){
-        eventPublisher.publisher(new NewMeetingEvent("강남역 카페",1L));
+        eventPublisher.publisher(new NewMeetingEvent("강남역 카페",1L,"12345"));
 
         return "ok";
     }

--- a/src/main/java/findme/dangdangcrew/notification/converter/NewMeetingNotificationConverter.java
+++ b/src/main/java/findme/dangdangcrew/notification/converter/NewMeetingNotificationConverter.java
@@ -20,6 +20,7 @@ public class NewMeetingNotificationConverter implements NotificationConverter{
                 notificationEntity.getMessage(),
                 notificationEntity.isRead(),
                 notificationEntity.getMeetingId(),
+                notificationEntity.getPlaceId(),
                 notificationEntity.getCreatedAt());
     }
 

--- a/src/main/java/findme/dangdangcrew/notification/domain/NewMeetingNotification.java
+++ b/src/main/java/findme/dangdangcrew/notification/domain/NewMeetingNotification.java
@@ -9,14 +9,17 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 public class NewMeetingNotification extends Notification{
     private Long meetingId;
+    private String placeId;
 
-    public NewMeetingNotification(Long targetUserId,String message, boolean isRead, Long meetingId, LocalDateTime createdAt){
+    public NewMeetingNotification(Long targetUserId, String message, boolean isRead, Long meetingId, String placeId, LocalDateTime createdAt){
         super(null, targetUserId, message, isRead , NotificationType.MEETING_CREATED, createdAt);
         this.meetingId = meetingId;
+        this.placeId = placeId;
     }
 
-    public NewMeetingNotification(Long id,Long targetUserId,String message, boolean isRead, Long meetingId, LocalDateTime createdAt){
+    public NewMeetingNotification(Long id,Long targetUserId,String message, boolean isRead, Long meetingId, String placeId, LocalDateTime createdAt){
         super(id, targetUserId,message,isRead ,NotificationType.MEETING_CREATED, createdAt);
         this.meetingId = meetingId;
+        this.placeId = placeId;
     }
 }

--- a/src/main/java/findme/dangdangcrew/notification/event/NewMeetingEvent.java
+++ b/src/main/java/findme/dangdangcrew/notification/event/NewMeetingEvent.java
@@ -5,6 +5,7 @@ package findme.dangdangcrew.notification.event;
  */
 public record NewMeetingEvent(
         String placeName,
-        Long meetingId
+        Long meetingId,
+        String placeId
 ) {
 }

--- a/src/main/java/findme/dangdangcrew/notification/event/NotificationEventListener.java
+++ b/src/main/java/findme/dangdangcrew/notification/event/NotificationEventListener.java
@@ -35,7 +35,7 @@ public class NotificationEventListener {
         // 생성 시각
         LocalDateTime createdAt = LocalDateTime.now();
 
-        // 미팅이 생성된 장소 정보 조회 -> 해당 장소를 즐겨찾기 한 유저 찾기
+        // 해당 장소를 즐겨찾기 한 유저 찾기
         List<FavoritePlace> favoritePlaces = favoritePlaceRepository.findAllByPlaceId(event.placeId());
         Set<Long> userIds = favoritePlaces.stream()
                 .map(favoritePlace -> favoritePlace.getUser().getId())

--- a/src/main/java/findme/dangdangcrew/notification/event/NotificationEventListener.java
+++ b/src/main/java/findme/dangdangcrew/notification/event/NotificationEventListener.java
@@ -27,7 +27,6 @@ public class NotificationEventListener {
     private final FavoritePlaceRepository favoritePlaceRepository;
     private final SseService sseService;
 
-// 이건 즐겨찾기 한 유저 전부에게 뿌려야 하므로 즐겨찾기 유저 찾는 다른 로직이 필요
     @EventListener
     public void handleNewMeetingNotification(NewMeetingEvent event) {
         // 보낼 메세지
@@ -36,9 +35,7 @@ public class NotificationEventListener {
         // 생성 시각
         LocalDateTime createdAt = LocalDateTime.now();
 
-        // 미팅이 생성된 장소에 즐겨찾기 한 유저 조회
         // 미팅이 생성된 장소 정보 조회 -> 해당 장소를 즐겨찾기 한 유저 찾기
-        // 즐겨찾기 한 유저들을 찾았으면 해당 유저가 연결이 되어있는지 찾기.
         List<FavoritePlace> favoritePlaces = favoritePlaceRepository.findAllByPlaceId(event.placeId());
         Set<Long> userIds = favoritePlaces.stream()
                 .map(favoritePlace -> favoritePlace.getUser().getId())
@@ -62,7 +59,6 @@ public class NotificationEventListener {
 
     }
 
-    //이건 연결되어있는 모든 유저한테 보내야 하므로 유저 찾기 로직이 필요
     @EventListener
     public void handleHotPlaceNotification(HotPlaceEvent event) {
         // 보낼 메세지
@@ -90,7 +86,6 @@ public class NotificationEventListener {
         sseService.broadcastHotPlace(connectUserId, message);
     }
 
-    // 이건 타겟이 단 한명이므로 현상 유지 괜찮을 듯
     @EventListener
     public void handleApplyNotification(ApplyEvent event) {
         // 보낼 메세지

--- a/src/main/java/findme/dangdangcrew/notification/event/NotificationEventListener.java
+++ b/src/main/java/findme/dangdangcrew/notification/event/NotificationEventListener.java
@@ -2,8 +2,11 @@ package findme.dangdangcrew.notification.event;
 
 import findme.dangdangcrew.notification.domain.ApplyNotification;
 import findme.dangdangcrew.notification.domain.HotPlaceNotification;
+import findme.dangdangcrew.notification.domain.NewMeetingNotification;
 import findme.dangdangcrew.notification.domain.Notification;
 import findme.dangdangcrew.notification.service.NotificationService;
+import findme.dangdangcrew.place.domain.FavoritePlace;
+import findme.dangdangcrew.place.repository.FavoritePlaceRepository;
 import findme.dangdangcrew.sse.service.SseService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.event.EventListener;
@@ -21,31 +24,43 @@ import java.util.stream.Collectors;
 public class NotificationEventListener {
 
     private final NotificationService notificationService;
+    private final FavoritePlaceRepository favoritePlaceRepository;
     private final SseService sseService;
 
-//    //이건 즐겨찾기 한 유저 전부에게 뿌려야 하므로 즐겨찾기 유저 찾는 다른 로직이 필요
-//    @EventListener
-//    public void handleNewMeetingNotification(NewMeetingEvent event) {
-//        // 보낼 메세지
-//        String message = "[" + event.placeName() + "]" + " 에 새로운 모임이 생성되었습니다";
-//
-//        // 생성 시각
-//        LocalDateTime createdAt = LocalDateTime.now();
-//
-//        // 미팅이 생성된 장소에 즐겨찾기 한 유저 조회
-//
-//
-//        // MeetingNotification 생성
-//        Notification notification = new NewMeetingNotification(
-//                event.targetUserId(),
-//                message,
-//                false,
-//                event.meetingId(),
-//                createdAt
-//        );
-//
-//        notificationService.saveNotification(notification);
-//    }
+// 이건 즐겨찾기 한 유저 전부에게 뿌려야 하므로 즐겨찾기 유저 찾는 다른 로직이 필요
+    @EventListener
+    public void handleNewMeetingNotification(NewMeetingEvent event) {
+        // 보낼 메세지
+        String message = "[" + event.placeName() + "]" + " 에 새로운 모임이 생성되었습니다";
+
+        // 생성 시각
+        LocalDateTime createdAt = LocalDateTime.now();
+
+        // 미팅이 생성된 장소에 즐겨찾기 한 유저 조회
+        // 미팅이 생성된 장소 정보 조회 -> 해당 장소를 즐겨찾기 한 유저 찾기
+        // 즐겨찾기 한 유저들을 찾았으면 해당 유저가 연결이 되어있는지 찾기.
+        List<FavoritePlace> favoritePlaces = favoritePlaceRepository.findAllByPlaceId(event.placeId());
+        Set<Long> userIds = favoritePlaces.stream()
+                .map(favoritePlace -> favoritePlace.getUser().getId())
+                .collect(Collectors.toSet());
+
+        // MeetingNotification 생성
+        List<Notification> notifications = userIds.stream()
+                        .map(userId-> new NewMeetingNotification(
+                                userId,
+                                message,
+                                false,
+                                event.meetingId(),
+                                event.placeId(),
+                                createdAt
+                        )).collect(Collectors.toList());
+
+        notificationService.saveAllNotification(notifications);
+
+        // 비동기 알림 보내기, 새로운 쓰레드에서는 트랜잭션이 전파되지 않음
+        sseService.broadcastNewMeeting(userIds, message);
+
+    }
 
     //이건 연결되어있는 모든 유저한테 보내야 하므로 유저 찾기 로직이 필요
     @EventListener
@@ -59,8 +74,7 @@ public class NotificationEventListener {
         // 현재 연결되어있는 유저들 조회
         Set<Long> connectUserId = sseService.getConnectedUserIds();
 
-
-        // MeetingNotification 생성
+        // HotPlaceNotification 생성
         List<Notification> notifications = connectUserId.stream()
                 .map(userId -> new HotPlaceNotification(
                         userId,

--- a/src/main/java/findme/dangdangcrew/place/repository/FavoritePlaceRepository.java
+++ b/src/main/java/findme/dangdangcrew/place/repository/FavoritePlaceRepository.java
@@ -13,5 +13,8 @@ public interface FavoritePlaceRepository extends JpaRepository<FavoritePlace, Lo
     boolean existsByUserAndPlace(User user, Place place);
 
     @Query("SELECT fp FROM FavoritePlace fp JOIN FETCH fp.place WHERE fp.user = :user")
-    List<FavoritePlace> findAllWithPlaceByUser(@Param("user") User user);
+    List<FavoritePlace> findAllByUser(@Param("user") User user);
+
+    @Query("SELECT fp FROM FavoritePlace fp JOIN FETCH fp.user WHERE fp.place.id = :placeId")
+    List<FavoritePlace> findAllByPlaceId(@Param("placeId") String placeId);
 }

--- a/src/main/java/findme/dangdangcrew/place/service/FavoritePlaceService.java
+++ b/src/main/java/findme/dangdangcrew/place/service/FavoritePlaceService.java
@@ -51,7 +51,7 @@ public class FavoritePlaceService {
 
     public List<FavoritePlaceResponseDto> getAllFavoritePlace(Long userId) {
         User user = userRepository.findById(userId).orElseThrow(()->new CustomException(ErrorCode.USER_NOT_FOUND));
-        List<FavoritePlace> favoritePlaces = favoritePlaceRepository.findAllWithPlaceByUser(user);
+        List<FavoritePlace> favoritePlaces = favoritePlaceRepository.findAllByUser(user);
 
         return favoritePlaces.stream()
                 .map(favoritePlace -> FavoritePlaceResponseDto.of(favoritePlace.getPlace(),user.getId()))

--- a/src/main/java/findme/dangdangcrew/sse/repository/EmitterRepository.java
+++ b/src/main/java/findme/dangdangcrew/sse/repository/EmitterRepository.java
@@ -4,6 +4,7 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 public interface EmitterRepository {
     SseEmitter save(String eventId, SseEmitter sseEmitter);
@@ -16,4 +17,5 @@ public interface EmitterRepository {
     Map<String, SseEmitter> findAllEmitters();
 
     SseEmitter findEmitterByUserId(Long userId);
+    Map<String, SseEmitter> findEmittersByUserId(Set<Long> userIds);
 }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 문서 수정
- [ ] 코드 리팩토링
- [ ] 테스트 코드 추가 및 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
dev

### 이슈
- closed #42 

### 변경 사항
1. handleNewMeetingNotification 의 로직을 수정하였습니다.
- 미팅이 생성된 장소 정보를 활용해서 해당 장소를 즐겨찾기 한 유저를 조회 한 뒤, 조회한 유저들의 연결을 확인하고 알림을 보내도록 하였습니다.
2. NewMeetingEvent 에 placeId 필드 추가
- 장소를 즐겨찾기 한 유저를 찾기 위해 placeId 필드를 추가하여 eventHandler에서 유저 찾기에 활용하였습니다.
3. MeetingService의 create 메서드에 이벤트 발행 코드 추가
- 장소에 미팅이 생길 때, 이벤트 발행을 위해 MeetingService에 코드를 추가하였습니다.


### 테스트 결과
*장소가 생성될 때 즐겨찾기 유저가 받는 알림 테스트
![1](https://github.com/user-attachments/assets/ac850996-472d-465c-ae85-154c2ecb6756)

![2](https://github.com/user-attachments/assets/92c816cc-d50a-4d13-a1e3-c6474cac1cd0)

