### PR TITLE
[#41] 토큰 기반 유저 조회 API 추가

### DIFF
--- a/src/main/java/findme/dangdangcrew/user/controller/UserController.java
+++ b/src/main/java/findme/dangdangcrew/user/controller/UserController.java
@@ -4,6 +4,7 @@ import findme.dangdangcrew.global.config.JwtTokenProvider;
 import findme.dangdangcrew.user.dto.*;
 import findme.dangdangcrew.user.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -56,5 +57,15 @@ public class UserController {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(null);
         }
     }
+
+    @GetMapping("/me")
+    @Operation(summary = "내 정보 조회", description = "JWT 토큰을 기반으로 본인 정보를 조회합니다.")
+    public ResponseEntity<UserResponseDto> getUserInfo(
+            @RequestHeader(value = "Authorization") String authorizationHeader) {
+
+        String token = jwtTokenProvider.extractToken(authorizationHeader);
+        return ResponseEntity.ok(userService.getUserInfo(token));
+    }
+
 
 }

--- a/src/main/java/findme/dangdangcrew/user/dto/UserResponseDto.java
+++ b/src/main/java/findme/dangdangcrew/user/dto/UserResponseDto.java
@@ -3,6 +3,7 @@ package findme.dangdangcrew.user.dto;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 
 @Getter
@@ -14,4 +15,5 @@ public class UserResponseDto {
     private String nickname;
     private String phoneNumber;
     private LocalDateTime createdAt;
+    private BigDecimal userScore;
 }

--- a/src/main/java/findme/dangdangcrew/user/service/UserService.java
+++ b/src/main/java/findme/dangdangcrew/user/service/UserService.java
@@ -120,7 +120,8 @@ public class UserService {
                 user.getName(),
                 user.getNickname(),
                 user.getPhoneNumber(),
-                user.getCreatedAt()
+                user.getCreatedAt(),
+                user.getUserScore()
         );
     }
 }

--- a/src/main/java/findme/dangdangcrew/user/service/UserService.java
+++ b/src/main/java/findme/dangdangcrew/user/service/UserService.java
@@ -105,4 +105,18 @@ public class UserService {
         }
     }
 
+    public UserResponseDto getUserInfo(String token) {
+        String email = jwtTokenProvider.getEmailFromToken(token);
+
+        User user = userRepository.findByEmail(email).orElseThrow(() -> new RuntimeException("User not found"));
+
+        return new UserResponseDto(
+                user.getId(),
+                user.getEmail(),
+                user.getName(),
+                user.getNickname(),
+                user.getPhoneNumber(),
+                user.getCreatedAt()
+        );
+    }
 }

--- a/src/main/java/findme/dangdangcrew/user/service/UserService.java
+++ b/src/main/java/findme/dangdangcrew/user/service/UserService.java
@@ -55,7 +55,7 @@ public class UserService {
                 .build();
         userRepository.save(user);
 
-        return new UserResponseDto(user.getId(), user.getEmail(), user.getName(), user.getNickname(), user.getPhoneNumber(), user.getCreatedAt());
+        return convertToDto(user);
     }
 
     public TokenResponseDto authenticate(LoginRequestDto request) {
@@ -110,6 +110,10 @@ public class UserService {
 
         User user = userRepository.findByEmail(email).orElseThrow(() -> new RuntimeException("User not found"));
 
+        return convertToDto(user);
+    }
+
+    private UserResponseDto convertToDto(User user) {
         return new UserResponseDto(
                 user.getId(),
                 user.getEmail(),


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [X] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 문서 수정
- [ ] 코드 리팩토링
- [ ] 테스트 코드 추가 및 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
dev

### 이슈
[#41 ]

### 변경 사항
로그인 후, 액세스 토큰으로 유저 조회 가능하도록 API 추가

### 테스트 결과
로그인 후 발급받은 액세스 토큰 값으로 유저 조회 가능
* 스웨거 우측 상단에 Authorize에도 액세스 토큰 등록
![유저 조회 API](https://github.com/user-attachments/assets/e30f3291-7008-4531-b56c-2a74981caae2)
