### PR TITLE
[#57] jwt filter 설계, 엔티티 반환 메서드 추가

### DIFF
--- a/src/main/java/findme/dangdangcrew/global/config/JwtTokenFilter.java
+++ b/src/main/java/findme/dangdangcrew/global/config/JwtTokenFilter.java
@@ -1,0 +1,48 @@
+package findme.dangdangcrew.global.config;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+public class JwtTokenFilter extends OncePerRequestFilter {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final UserDetailsService userDetailsService;
+
+    public JwtTokenFilter(JwtTokenProvider jwtTokenProvider, UserDetailsService userDetailsService) {
+        this.jwtTokenProvider = jwtTokenProvider;
+        this.userDetailsService = userDetailsService;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
+            throws ServletException, IOException {
+
+        // 1. 요청에서 Authorization 헤더 가져오기
+        String token = jwtTokenProvider.resolveToken(request);
+
+        if (token != null && jwtTokenProvider.validateToken(token)) {
+            // 2. 토큰에서 사용자 정보 추출
+            String email = jwtTokenProvider.getEmailFromToken(token);
+            UserDetails userDetails = userDetailsService.loadUserByUsername(email);
+
+            // 3. Spring Security 인증 객체 생성
+            UsernamePasswordAuthenticationToken authentication =
+                    new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+            // 4. SecurityContextHolder에 저장
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+
+        chain.doFilter(request, response);
+    }
+}

--- a/src/main/java/findme/dangdangcrew/global/config/JwtTokenFilter.java
+++ b/src/main/java/findme/dangdangcrew/global/config/JwtTokenFilter.java
@@ -1,5 +1,7 @@
 package findme.dangdangcrew.global.config;
 
+import findme.dangdangcrew.global.exception.CustomException;
+import findme.dangdangcrew.global.exception.ErrorCode;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -8,8 +10,6 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
-import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
-import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
@@ -27,20 +27,21 @@ public class JwtTokenFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
             throws ServletException, IOException {
-
         // 1. 요청에서 Authorization 헤더 가져오기
         String token = jwtTokenProvider.resolveToken(request);
-
-        if (token != null && jwtTokenProvider.validateToken(token)) {
-            // 2. 토큰에서 사용자 정보 추출
-            String email = jwtTokenProvider.getEmailFromToken(token);
-            UserDetails userDetails = userDetailsService.loadUserByUsername(email);
-
-            // 3. Spring Security 인증 객체 생성
-            UsernamePasswordAuthenticationToken authentication =
-                    new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
-            // 4. SecurityContextHolder에 저장
-            SecurityContextHolder.getContext().setAuthentication(authentication);
+        try {
+            if (token != null && jwtTokenProvider.validateToken(token)) {
+                // 2. 토큰에서 사용자 정보 추출
+                String email = jwtTokenProvider.getEmailFromToken(token);
+                UserDetails userDetails = userDetailsService.loadUserByUsername(email);
+                // 3. Spring Security 인증 객체 생성
+                UsernamePasswordAuthenticationToken authentication =
+                        new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+                // 4. SecurityContextHolder에 저장
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            }
+        } catch (Exception e) {
+            throw new CustomException(ErrorCode.INVALID_TOKEN);
         }
 
         chain.doFilter(request, response);

--- a/src/main/java/findme/dangdangcrew/global/config/JwtTokenProvider.java
+++ b/src/main/java/findme/dangdangcrew/global/config/JwtTokenProvider.java
@@ -1,5 +1,7 @@
 package findme.dangdangcrew.global.config;
 
+import findme.dangdangcrew.global.exception.CustomException;
+import findme.dangdangcrew.global.exception.ErrorCode;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
 import jakarta.servlet.http.HttpServletRequest;
@@ -49,12 +51,16 @@ public class JwtTokenProvider {
     }
 
     public String getEmailFromToken(String token) {
-        return Jwts.parserBuilder()
-                .setSigningKey(key)
-                .build()
-                .parseClaimsJws(token.trim())
-                .getBody()
-                .getSubject();
+        try {
+            return Jwts.parserBuilder()
+                    .setSigningKey(key)
+                    .build()
+                    .parseClaimsJws(token.trim())
+                    .getBody()
+                    .getSubject();
+        } catch (JwtException e) {
+            throw new CustomException(ErrorCode.INVALID_TOKEN);
+        }
     }
 
     public boolean validateToken(String token) {
@@ -62,16 +68,15 @@ public class JwtTokenProvider {
             Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
             return true;
         } catch (ExpiredJwtException e) {
-            log.error("Expired JWT token");
+            throw new CustomException(ErrorCode.EXPIRED_TOKEN);
         } catch (JwtException e) {
-            log.error("Invalid JWT token");
+            throw new CustomException(ErrorCode.INVALID_TOKEN);
         }
-        return false;
     }
 
     public String extractToken(String authorizationHeader) {
         if (authorizationHeader == null || !authorizationHeader.startsWith("Bearer ")) {
-            throw new RuntimeException("Missing or invalid Authorization header");
+            throw new CustomException(ErrorCode.MISSING_TOKEN);
         }
         return authorizationHeader.substring(7).trim();
     }

--- a/src/main/java/findme/dangdangcrew/global/config/JwtTokenProvider.java
+++ b/src/main/java/findme/dangdangcrew/global/config/JwtTokenProvider.java
@@ -2,6 +2,7 @@ package findme.dangdangcrew.global.config;
 
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -73,6 +74,14 @@ public class JwtTokenProvider {
             throw new RuntimeException("Missing or invalid Authorization header");
         }
         return authorizationHeader.substring(7).trim();
+    }
+
+    public String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        if (bearerToken != null && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7); // "Bearer " 이후의 토큰 부분만 추출
+        }
+        return null;
     }
 
 }

--- a/src/main/java/findme/dangdangcrew/global/config/SecurityConfig.java
+++ b/src/main/java/findme/dangdangcrew/global/config/SecurityConfig.java
@@ -1,14 +1,29 @@
 package findme.dangdangcrew.global.config;
 
+import findme.dangdangcrew.user.repository.UserRepository;
+import findme.dangdangcrew.user.service.CustomUserDetailsService;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
 
 @Configuration
 public class SecurityConfig {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final UserDetailsService userDetailsService;
+
+    public SecurityConfig(JwtTokenProvider jwtTokenProvider, UserDetailsService userDetailsService) {
+        this.jwtTokenProvider = jwtTokenProvider;
+        this.userDetailsService = userDetailsService;
+    }
 
     @Bean
     public BCryptPasswordEncoder passwordEncoder(){
@@ -16,7 +31,20 @@ public class SecurityConfig {
     }
 
     @Bean
+    public AuthenticationManager authenticationManager(
+            AuthenticationConfiguration authenticationConfiguration) throws Exception {
+        return authenticationConfiguration.getAuthenticationManager();
+    }
+
+    @Bean
+    public UserDetailsService userDetailsService(UserRepository userRepository) {
+        return new CustomUserDetailsService(userRepository);
+    }
+
+    @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        JwtTokenFilter jwtTokenFilter = new JwtTokenFilter(jwtTokenProvider, userDetailsService); // 필터 직접 생성
+
         http
                 .csrf(AbstractHttpConfigurer::disable) // CSRF 비활성화
                 .authorizeHttpRequests(auth -> auth
@@ -27,6 +55,7 @@ public class SecurityConfig {
                         .requestMatchers("/api/v1/users/logout").authenticated()
                         .anyRequest().authenticated()
                 )
+                .addFilterBefore(jwtTokenFilter, UsernamePasswordAuthenticationFilter.class) // 필터 직접 추가
                 .formLogin(AbstractHttpConfigurer::disable);
 
         return http.build();

--- a/src/main/java/findme/dangdangcrew/global/exception/ErrorCode.java
+++ b/src/main/java/findme/dangdangcrew/global/exception/ErrorCode.java
@@ -30,6 +30,10 @@ public enum ErrorCode {
     INVALID_PARAMETER(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
     INVALID_JSON_FORMAT(HttpStatus.BAD_REQUEST, "요청한 JSON 형식이 올바르지 않습니다."),
 
+    // JWT Token Error
+    EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "토큰이 만료되었습니다."),
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
+    MISSING_TOKEN(HttpStatus.BAD_REQUEST, "토큰이 누락되었습니다."),
     ;
 
     private final HttpStatus status;

--- a/src/main/java/findme/dangdangcrew/user/controller/UserController.java
+++ b/src/main/java/findme/dangdangcrew/user/controller/UserController.java
@@ -2,6 +2,7 @@ package findme.dangdangcrew.user.controller;
 
 import findme.dangdangcrew.global.config.JwtTokenProvider;
 import findme.dangdangcrew.user.dto.*;
+import findme.dangdangcrew.user.entity.User;
 import findme.dangdangcrew.user.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -46,25 +47,21 @@ public class UserController {
 
     @PostMapping("/logout")
     @Operation(summary = "로그아웃", description = "로그아웃을 수행하고 Refresh Token을 삭제합니다.")
-    public ResponseEntity<Void> logout(@RequestHeader(value = "authorization", required = false) String token) {
-        logger.info("🚀 Received Authorization Header: {}", token);
-        try {
-            String accessToken = jwtTokenProvider.extractToken(token);
-            userService.logout(accessToken);
-            return ResponseEntity.noContent().build();
-        } catch (RuntimeException e) {
-            logger.error("❌ {}", e.getMessage());
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(null);
-        }
+    public ResponseEntity<Void> logout() {
+        userService.logout();
+        return ResponseEntity.noContent().build();
     }
 
     @GetMapping("/me")
     @Operation(summary = "내 정보 조회", description = "JWT 토큰을 기반으로 본인 정보를 조회합니다.")
-    public ResponseEntity<UserResponseDto> getUserInfo(
-            @RequestHeader(value = "Authorization") String authorizationHeader) {
+    public ResponseEntity<UserResponseDto> getUserInfo() {
+        return ResponseEntity.ok(userService.getUserInfo());
+    }
 
-        String token = jwtTokenProvider.extractToken(authorizationHeader);
-        return ResponseEntity.ok(userService.getUserInfo(token));
+    @GetMapping("/me/entity")
+    @Operation(summary = "내 엔티티 조회", description = "JWT 토큰을 기반으로 본인 `User` 엔티티 정보를 반환합니다.")
+    public ResponseEntity<User> getCurrentUserEntity() {
+        return ResponseEntity.ok(userService.getCurrentUser());
     }
 
 }

--- a/src/main/java/findme/dangdangcrew/user/service/CustomUserDetailsService.java
+++ b/src/main/java/findme/dangdangcrew/user/service/CustomUserDetailsService.java
@@ -1,10 +1,11 @@
 package findme.dangdangcrew.user.service;
 
+import findme.dangdangcrew.global.exception.CustomException;
+import findme.dangdangcrew.global.exception.ErrorCode;
 import findme.dangdangcrew.user.entity.User;
 import findme.dangdangcrew.user.repository.UserRepository;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
-import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -17,14 +18,14 @@ public class CustomUserDetailsService implements UserDetailsService {
     }
 
     @Override
-    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+    public UserDetails loadUserByUsername(String email) {
         User user = userRepository.findByEmail(email)
-                .orElseThrow(() -> new UsernameNotFoundException("User not found with email: " + email));
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
         return org.springframework.security.core.userdetails.User.builder()
                 .username(user.getEmail())
-                .password(user.getPassword()) // Spring Security에서 비밀번호 검증에 사용
-                .roles("USER") // 기본 역할 설정 (필요에 따라 변경 가능)
+                .password(user.getPassword())
+                .roles("USER")
                 .build();
     }
 }

--- a/src/main/java/findme/dangdangcrew/user/service/CustomUserDetailsService.java
+++ b/src/main/java/findme/dangdangcrew/user/service/CustomUserDetailsService.java
@@ -1,0 +1,30 @@
+package findme.dangdangcrew.user.service;
+
+import findme.dangdangcrew.user.entity.User;
+import findme.dangdangcrew.user.repository.UserRepository;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    public CustomUserDetailsService(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new UsernameNotFoundException("User not found with email: " + email));
+
+        return org.springframework.security.core.userdetails.User.builder()
+                .username(user.getEmail())
+                .password(user.getPassword()) // Spring Security에서 비밀번호 검증에 사용
+                .roles("USER") // 기본 역할 설정 (필요에 따라 변경 가능)
+                .build();
+    }
+}


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [X] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 문서 수정
- [X] 코드 리팩토링
- [ ] 테스트 코드 추가 및 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
dev

### 이슈
[#57 ]

### 변경 사항
리팩토링 사항
- jwtfilter 구현으로 token 관리, 컨트롤러에서 토큰 처리 제거
- jwt 인증 필터 및 보안 설정 추가
기능 추가
- 관련 도메인에서의 유저 정보 획득을 위한 현재 로그인한 사용자 정보 조회 API 추가(엔티티 반환)
- CustomUserDetailsService 구현 

### 테스트 결과
- 로그인 후, 스웨거 우측 상단 Authorize에 액세스 토큰 입력 후 진행
**리팩토링한 내 정보 조회 API 결과**
![스크린샷 2025-02-13 오후 5 33 22](https://github.com/user-attachments/assets/3148fbfb-ce57-49b0-a3c9-fed12baedac0)
**현재 로그인한 사용자 정보 조회 API** 
![스크린샷 2025-02-13 오후 5 33 30](https://github.com/user-attachments/assets/c14a9b66-818a-4a0f-8b27-92b7c7472ce0)

