### PR TITLE
[#58] 중복 입퇴장 불가 구현

### DIFF
--- a/src/main/java/findme/dangdangcrew/chat/controller/ChatController.java
+++ b/src/main/java/findme/dangdangcrew/chat/controller/ChatController.java
@@ -25,7 +25,8 @@ public class ChatController {
             @DestinationVariable Long roomId,
             @Payload ChatMessageRequestDto chatMessage) {
 
-        String message = chatRoomService.processChat(chatMessage, roomId);
+        Long userId = 1L; // 토큰 값에서 User 정보 추출해오는 로직이 없어서 에러가 생겨서 일단 임시로 넣어놓음.
+        String message = chatRoomService.processChat(chatMessage, roomId, userId); // 추후 토큰 기반 유저 정보 추출이 개발되면 userId 파라미터 삭제 예정.
 
         return new ChatMessageResponseDto(
                 String.valueOf(roomId),

--- a/src/main/java/findme/dangdangcrew/chat/controller/ChatHistoryController.java
+++ b/src/main/java/findme/dangdangcrew/chat/controller/ChatHistoryController.java
@@ -2,6 +2,8 @@ package findme.dangdangcrew.chat.controller;
 
 import findme.dangdangcrew.chat.dto.ChatMessageResponseDto;
 import findme.dangdangcrew.chat.service.ChatMessageService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -13,11 +15,13 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/chat")
+@Tag(name = "[Chat] Chat API", description = "채팅 관련 API")
 public class ChatHistoryController {
 
     private final ChatMessageService chatMessageService;
 
     @GetMapping("/{roomId}")
+    @Operation(summary = "채팅 내역 불러오기", description = "이전 채팅 내역을 불러옵니다.")
     public ResponseEntity<List<ChatMessageResponseDto>> getChatHistory(@PathVariable Long roomId) {
         List<ChatMessageResponseDto> chatHistory = chatMessageService.getMessages(roomId);
         return ResponseEntity.ok(chatHistory);

--- a/src/main/java/findme/dangdangcrew/chat/entity/ChatParticipant.java
+++ b/src/main/java/findme/dangdangcrew/chat/entity/ChatParticipant.java
@@ -1,0 +1,40 @@
+package findme.dangdangcrew.chat.entity;
+
+import findme.dangdangcrew.user.entity.User;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@AllArgsConstructor
+@Table(name = "chat_participant", uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"room_id", "user_id"})
+})
+public class ChatParticipant {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "room_id", nullable = false)
+    private ChatRoom chatRoom;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+}

--- a/src/main/java/findme/dangdangcrew/chat/entity/ChatParticipant.java
+++ b/src/main/java/findme/dangdangcrew/chat/entity/ChatParticipant.java
@@ -19,7 +19,6 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
 @Table(name = "chat_participant", uniqueConstraints = {
         @UniqueConstraint(columnNames = {"room_id", "user_id"})
 })

--- a/src/main/java/findme/dangdangcrew/chat/entity/ChatParticipant.java
+++ b/src/main/java/findme/dangdangcrew/chat/entity/ChatParticipant.java
@@ -19,7 +19,6 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Builder
 @AllArgsConstructor
 @Table(name = "chat_participant", uniqueConstraints = {
         @UniqueConstraint(columnNames = {"room_id", "user_id"})
@@ -37,4 +36,10 @@ public class ChatParticipant {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
+
+    @Builder
+    public ChatParticipant(ChatRoom chatRoom, User user) {
+        this.chatRoom = chatRoom;
+        this.user = user;
+    }
 }

--- a/src/main/java/findme/dangdangcrew/chat/entity/ChatRoom.java
+++ b/src/main/java/findme/dangdangcrew/chat/entity/ChatRoom.java
@@ -1,5 +1,7 @@
 package findme.dangdangcrew.chat.entity;
 
+import findme.dangdangcrew.global.exception.CustomException;
+import findme.dangdangcrew.global.exception.ErrorCode;
 import findme.dangdangcrew.meeting.entity.Meeting;
 import findme.dangdangcrew.user.entity.User;
 import jakarta.persistence.Entity;
@@ -36,12 +38,11 @@ public class ChatRoom {
         this.currentParticipants = 1; // 방장이 자동으로 입장
     }
 
-    public boolean addParticipant() {
-        if (currentParticipants < MAX_PARTICIPANTS) {
-            currentParticipants++;
-            return true;
+    public void addParticipant() {
+        if (currentParticipants >= MAX_PARTICIPANTS) {
+            throw new CustomException(ErrorCode.CHAT_ROOM_FULL);
         }
-        return false;
+        currentParticipants++;
     }
 
     public void removeParticipant() {

--- a/src/main/java/findme/dangdangcrew/chat/repository/ChatParticipantRepository.java
+++ b/src/main/java/findme/dangdangcrew/chat/repository/ChatParticipantRepository.java
@@ -1,0 +1,13 @@
+package findme.dangdangcrew.chat.repository;
+
+import findme.dangdangcrew.chat.entity.ChatParticipant;
+import findme.dangdangcrew.chat.entity.ChatRoom;
+import findme.dangdangcrew.user.entity.User;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ChatParticipantRepository extends JpaRepository<ChatParticipant, Long> {
+    Optional<ChatParticipant> findByChatRoomAndUser(ChatRoom chatRoom, User user);
+
+    void deleteByChatRoomAndUser(ChatRoom chatRoom, User user);
+}

--- a/src/main/java/findme/dangdangcrew/chat/service/ChatRoomService.java
+++ b/src/main/java/findme/dangdangcrew/chat/service/ChatRoomService.java
@@ -2,6 +2,7 @@ package findme.dangdangcrew.chat.service;
 
 import findme.dangdangcrew.chat.dto.ChatMessageRequestDto;
 import findme.dangdangcrew.chat.dto.ChatMessageRequestDto.MessageType;
+import findme.dangdangcrew.chat.entity.ChatParticipant;
 import findme.dangdangcrew.chat.entity.ChatRoom;
 import findme.dangdangcrew.chat.repository.ChatParticipantRepository;
 import findme.dangdangcrew.chat.repository.ChatRoomRepository;
@@ -42,6 +43,7 @@ public class ChatRoomService {
         User user = userService.getUser(userId);
         checkIfAlreadyJoined(chatRoom, user);
 
+        saveChatParticipant(chatRoom, user);
         chatRoom.addParticipant();
     }
 
@@ -73,5 +75,13 @@ public class ChatRoomService {
 
     public void createChatRoom(Meeting meeting) {
         chatRoomRepository.save(new ChatRoom(meeting));
+    }
+
+    private void saveChatParticipant(ChatRoom chatRoom, User user) {
+        ChatParticipant chatParticipant = ChatParticipant.builder()
+                .chatRoom(chatRoom)
+                .user(user)
+                .build();
+        chatParticipantRepository.save(chatParticipant);
     }
 }

--- a/src/main/java/findme/dangdangcrew/chat/service/ChatRoomService.java
+++ b/src/main/java/findme/dangdangcrew/chat/service/ChatRoomService.java
@@ -30,7 +30,7 @@ public class ChatRoomService {
             return chatMessage.getSender() + "님이 입장하셨습니다.";
         }
         if (chatMessage.getType() == ChatMessageRequestDto.MessageType.LEAVE) {
-            leaveRoom(roomId);
+            leaveRoom(roomId, userId);
             return chatMessage.getSender() + "님이 퇴장하셨습니다.";
         }
         chatMessageService.saveMessage(chatMessage, roomId);
@@ -47,8 +47,11 @@ public class ChatRoomService {
         }
     }
 
-    public void leaveRoom(Long roomId) {
+    public void leaveRoom(Long roomId, Long userId) {
         ChatRoom chatRoom = getChatRoom(roomId);
+        User user = userService.getUser(userId);
+        checkIfAlreadyLeft(chatRoom, user);
+
         chatRoom.removeParticipant();
     }
 
@@ -61,6 +64,12 @@ public class ChatRoomService {
     public void checkIfAlreadyJoined(ChatRoom chatRoom, User user) {
         if (chatParticipantRepository.findByChatRoomAndUser(chatRoom, user).isPresent()) {
             throw new CustomException(ErrorCode.ALREADY_JOINED);
+        }
+    }
+
+    public void checkIfAlreadyLeft(ChatRoom chatRoom, User user) {
+        if (chatParticipantRepository.findByChatRoomAndUser(chatRoom, user).isEmpty()) {
+            throw new CustomException(ErrorCode.ALREADY_LEFT);
         }
     }
 

--- a/src/main/java/findme/dangdangcrew/chat/service/ChatRoomService.java
+++ b/src/main/java/findme/dangdangcrew/chat/service/ChatRoomService.java
@@ -4,6 +4,8 @@ import findme.dangdangcrew.chat.dto.ChatMessageRequestDto;
 import findme.dangdangcrew.chat.dto.ChatMessageRequestDto.MessageType;
 import findme.dangdangcrew.chat.entity.ChatRoom;
 import findme.dangdangcrew.chat.repository.ChatRoomRepository;
+import findme.dangdangcrew.global.exception.CustomException;
+import findme.dangdangcrew.global.exception.ErrorCode;
 import findme.dangdangcrew.meeting.entity.Meeting;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -33,7 +35,7 @@ public class ChatRoomService {
     public void enterRoom(Long roomId) {
         ChatRoom chatRoom = getChatRoom(roomId);
         if (!chatRoom.addParticipant()) {
-            throw new IllegalStateException("채팅방이 가득 찼습니다. (최대 20명)");
+            throw new CustomException(ErrorCode.CHAT_ROOM_FULL);
         }
     }
 
@@ -44,7 +46,7 @@ public class ChatRoomService {
 
     private ChatRoom getChatRoom(Long roomId) {
         ChatRoom chatRoom = chatRoomRepository.findById(roomId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 채팅방입니다."));
+                .orElseThrow(() -> new CustomException(ErrorCode.CHAT_ROOM_NOT_FOUND));
         return chatRoom;
     }
 

--- a/src/main/java/findme/dangdangcrew/chat/service/ChatRoomService.java
+++ b/src/main/java/findme/dangdangcrew/chat/service/ChatRoomService.java
@@ -42,9 +42,7 @@ public class ChatRoomService {
         User user = userService.getUser(userId);
         checkIfAlreadyJoined(chatRoom, user);
 
-        if (!chatRoom.addParticipant()) {
-            throw new CustomException(ErrorCode.CHAT_ROOM_FULL);
-        }
+        chatRoom.addParticipant();
     }
 
     public void leaveRoom(Long roomId, Long userId) {

--- a/src/main/java/findme/dangdangcrew/chat/service/ChatRoomService.java
+++ b/src/main/java/findme/dangdangcrew/chat/service/ChatRoomService.java
@@ -3,10 +3,13 @@ package findme.dangdangcrew.chat.service;
 import findme.dangdangcrew.chat.dto.ChatMessageRequestDto;
 import findme.dangdangcrew.chat.dto.ChatMessageRequestDto.MessageType;
 import findme.dangdangcrew.chat.entity.ChatRoom;
+import findme.dangdangcrew.chat.repository.ChatParticipantRepository;
 import findme.dangdangcrew.chat.repository.ChatRoomRepository;
 import findme.dangdangcrew.global.exception.CustomException;
 import findme.dangdangcrew.global.exception.ErrorCode;
 import findme.dangdangcrew.meeting.entity.Meeting;
+import findme.dangdangcrew.user.entity.User;
+import findme.dangdangcrew.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -18,10 +21,12 @@ public class ChatRoomService {
 
     private final ChatRoomRepository chatRoomRepository;
     private final ChatMessageService chatMessageService;
+    private final UserService userService;
+    private final ChatParticipantRepository chatParticipantRepository;
 
-    public String processChat(ChatMessageRequestDto chatMessage, Long roomId) {
+    public String processChat(ChatMessageRequestDto chatMessage, Long roomId, Long userId) {
         if (chatMessage.getType() == ChatMessageRequestDto.MessageType.ENTER) {
-            enterRoom(roomId);
+            enterRoom(roomId, userId);
             return chatMessage.getSender() + "님이 입장하셨습니다.";
         }
         if (chatMessage.getType() == ChatMessageRequestDto.MessageType.LEAVE) {
@@ -32,8 +37,11 @@ public class ChatRoomService {
         return chatMessage.getMessage();
     }
 
-    public void enterRoom(Long roomId) {
+    public void enterRoom(Long roomId, Long userId) {
         ChatRoom chatRoom = getChatRoom(roomId);
+        User user = userService.getUser(userId);
+        checkIfAlreadyJoined(chatRoom, user);
+
         if (!chatRoom.addParticipant()) {
             throw new CustomException(ErrorCode.CHAT_ROOM_FULL);
         }
@@ -48,6 +56,12 @@ public class ChatRoomService {
         ChatRoom chatRoom = chatRoomRepository.findById(roomId)
                 .orElseThrow(() -> new CustomException(ErrorCode.CHAT_ROOM_NOT_FOUND));
         return chatRoom;
+    }
+
+    public void checkIfAlreadyJoined(ChatRoom chatRoom, User user) {
+        if (chatParticipantRepository.findByChatRoomAndUser(chatRoom, user).isPresent()) {
+            throw new CustomException(ErrorCode.ALREADY_JOINED);
+        }
     }
 
     public void createChatRoom(Meeting meeting) {

--- a/src/main/java/findme/dangdangcrew/chat/service/ChatRoomService.java
+++ b/src/main/java/findme/dangdangcrew/chat/service/ChatRoomService.java
@@ -52,6 +52,7 @@ public class ChatRoomService {
         User user = userService.getUser(userId);
         checkIfAlreadyLeft(chatRoom, user);
 
+        chatParticipantRepository.deleteByChatRoomAndUser(chatRoom, user);
         chatRoom.removeParticipant();
     }
 

--- a/src/main/java/findme/dangdangcrew/global/exception/ErrorCode.java
+++ b/src/main/java/findme/dangdangcrew/global/exception/ErrorCode.java
@@ -34,6 +34,7 @@ public enum ErrorCode {
     CHAT_ROOM_FULL(HttpStatus.BAD_REQUEST, "채팅방이 가득 찼습니다. (최대 20명)"),
     CHAT_ROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 채팅방입니다."),
     ALREADY_JOINED(HttpStatus.BAD_REQUEST, "이미 채팅방에 참여한 사용자입니다."),
+    ALREADY_LEFT(HttpStatus.BAD_REQUEST, "이미 채팅방을 나간 사용자입니다."),
     ;
 
     private final HttpStatus status;

--- a/src/main/java/findme/dangdangcrew/global/exception/ErrorCode.java
+++ b/src/main/java/findme/dangdangcrew/global/exception/ErrorCode.java
@@ -33,6 +33,7 @@ public enum ErrorCode {
     // Chat Error
     CHAT_ROOM_FULL(HttpStatus.BAD_REQUEST, "채팅방이 가득 찼습니다. (최대 20명)"),
     CHAT_ROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 채팅방입니다."),
+    ALREADY_JOINED(HttpStatus.BAD_REQUEST, "이미 채팅방에 참여한 사용자입니다."),
     ;
 
     private final HttpStatus status;

--- a/src/main/java/findme/dangdangcrew/global/exception/ErrorCode.java
+++ b/src/main/java/findme/dangdangcrew/global/exception/ErrorCode.java
@@ -30,6 +30,9 @@ public enum ErrorCode {
     INVALID_PARAMETER(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
     INVALID_JSON_FORMAT(HttpStatus.BAD_REQUEST, "요청한 JSON 형식이 올바르지 않습니다."),
 
+    // Chat Error
+    CHAT_ROOM_FULL(HttpStatus.BAD_REQUEST, "채팅방이 가득 찼습니다. (최대 20명)"),
+    CHAT_ROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 채팅방입니다."),
     ;
 
     private final HttpStatus status;

--- a/src/main/java/findme/dangdangcrew/user/service/UserService.java
+++ b/src/main/java/findme/dangdangcrew/user/service/UserService.java
@@ -1,6 +1,8 @@
 package findme.dangdangcrew.user.service;
 
 import findme.dangdangcrew.global.config.JwtTokenProvider;
+import findme.dangdangcrew.global.exception.CustomException;
+import findme.dangdangcrew.global.exception.ErrorCode;
 import findme.dangdangcrew.user.controller.UserController;
 import findme.dangdangcrew.user.dto.*;
 import findme.dangdangcrew.user.entity.User;
@@ -123,5 +125,10 @@ public class UserService {
                 user.getCreatedAt(),
                 user.getUserScore()
         );
+    }
+
+    public User getUser(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
     }
 }

--- a/src/main/java/findme/dangdangcrew/user/service/UserService.java
+++ b/src/main/java/findme/dangdangcrew/user/service/UserService.java
@@ -127,6 +127,7 @@ public class UserService {
     public User getUser(Long userId) {
         return userRepository.findById(userId)
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+    }
       
     public User getCurrentUser() {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [X] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 문서 수정
- [ ] 코드 리팩토링
- [ ] 테스트 코드 추가 및 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
dev

### 이슈
closed #58 

### 변경 사항
1. 채팅방 참여자를 관리하여 중복 입장과 중복 퇴장을 막음.
2. ChatHistoryController에 swagger 관련 어노테이션 추가

### 테스트 결과
WebSocket Debug Tool 로 중복 입장, 퇴장 시 예외처리 발생
1.
![image](https://github.com/user-attachments/assets/f175909a-1bda-42dc-a024-1215a5de23de)
2.
![image](https://github.com/user-attachments/assets/f3da773a-2acf-4ca8-98d0-32201377ed21)
