### PR TITLE
[#53] 모임 도메인에서 User 정보 가져오는 부분 수정

### DIFF
--- a/src/main/java/findme/dangdangcrew/global/exception/ErrorCode.java
+++ b/src/main/java/findme/dangdangcrew/global/exception/ErrorCode.java
@@ -28,6 +28,7 @@ public enum ErrorCode {
     MEETING_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 미팅을 찾을 수  없습니다."),
     MEETING_EXCEED_LIMIT_PEOPLE(HttpStatus.BAD_REQUEST, "현재 인원은 최대 인원을 초과할 수 없습니다."),
     MEETING_INSUFFICIENT_PEOPLE(HttpStatus.BAD_REQUEST, "현재 인원은 1명 미만이 될 수 없습니다."),
+    NOT_LEADER(HttpStatus.BAD_REQUEST, "현재 로그인한 유저는 리더가 아닙니다."),
 
     // Invalidation Error
     INVALID_PARAMETER(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),

--- a/src/main/java/findme/dangdangcrew/global/exception/ErrorCode.java
+++ b/src/main/java/findme/dangdangcrew/global/exception/ErrorCode.java
@@ -29,6 +29,7 @@ public enum ErrorCode {
     MEETING_EXCEED_LIMIT_PEOPLE(HttpStatus.BAD_REQUEST, "현재 인원은 최대 인원을 초과할 수 없습니다."),
     MEETING_INSUFFICIENT_PEOPLE(HttpStatus.BAD_REQUEST, "현재 인원은 1명 미만이 될 수 없습니다."),
     NOT_LEADER(HttpStatus.BAD_REQUEST, "현재 로그인한 유저는 리더가 아닙니다."),
+    NOT_CHANGE(HttpStatus.BAD_REQUEST, "이전 상태와 동일합니다."),
 
     // Invalidation Error
     INVALID_PARAMETER(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),

--- a/src/main/java/findme/dangdangcrew/meeting/controller/MeetingController.java
+++ b/src/main/java/findme/dangdangcrew/meeting/controller/MeetingController.java
@@ -18,10 +18,10 @@ public class MeetingController {
 
     private final MeetingService meetingService;
 
-    @PostMapping("/{userId}")
+    @PostMapping
     @Operation(summary = "모임 생성", description = "모임을 생성합니다.")
-    public ResponseEntity<MeetingApplicationResponseDto> createMeeting(@RequestBody MeetingRequestDto dto, @PathVariable("userId") Long userId){
-        MeetingApplicationResponseDto response = meetingService.create(dto, userId);
+    public ResponseEntity<MeetingApplicationResponseDto> createMeeting(@RequestBody MeetingRequestDto dto){
+        MeetingApplicationResponseDto response = meetingService.create(dto);
         return ResponseEntity.ok(response);
     }
 
@@ -32,24 +32,24 @@ public class MeetingController {
         return ResponseEntity.ok(response);
     }
 
-    @PostMapping("/{meetingId}/{userId}")
+    @PostMapping("/{meetingId}/apply")
     @Operation(summary = "모임 참가 신청", description = "유저가 모임 참가 신청합니다.")
-    public ResponseEntity<MeetingApplicationResponseDto> applyMeeting(@PathVariable("meetingId") Long meetingId, @PathVariable("userId") Long userId){
-        MeetingApplicationResponseDto response = meetingService.applyMeetingByMeetingId(meetingId, userId);
+    public ResponseEntity<MeetingApplicationResponseDto> applyMeeting(@PathVariable("meetingId") Long meetingId){
+        MeetingApplicationResponseDto response = meetingService.applyMeetingByMeetingId(meetingId);
         return ResponseEntity.ok(response);
     }
 
-    @PutMapping("/{metingId}/{userId}/cancel")
+    @PatchMapping("/{meetingId}/apply")
     @Operation(summary = "모임 참가 취소", description = "유저가 모임 참가를 취소합니다.")
-    public ResponseEntity<MeetingApplicationResponseDto> cancelMeetingApplication(@PathVariable("metingId") Long meetingId, @PathVariable("userId") Long userId){
-        MeetingApplicationResponseDto response = meetingService.cancelMeetingApplication(meetingId, userId);
+    public ResponseEntity<MeetingApplicationResponseDto> cancelMeetingApplication(@PathVariable("meetingId") Long meetingId){
+        MeetingApplicationResponseDto response = meetingService.cancelMeetingApplication(meetingId);
         return ResponseEntity.ok(response);
     }
 
-    @PutMapping("/{meetingId}/status")
+    @PutMapping("/{meetingId}/applications/status")
     @Operation(summary = "(모임 생성자) 모임 상태 변경", description = "모임 생성자가 모임 신청 유저들을 확정/취소합니다.")
     public ResponseEntity<MeetingApplicationResponseDto> updateApplicationStatusByLeader(@PathVariable("meetingId") Long meetingId,
-                                                                               MeetingApplicationUpdateRequestDto dto){
+                                                                               @RequestBody MeetingApplicationUpdateRequestDto dto){
         MeetingApplicationResponseDto response = meetingService.changeMeetingApplicationStatusByLeader(meetingId, dto);
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/findme/dangdangcrew/meeting/controller/MeetingController.java
+++ b/src/main/java/findme/dangdangcrew/meeting/controller/MeetingController.java
@@ -39,7 +39,7 @@ public class MeetingController {
         return ResponseEntity.ok(response);
     }
 
-    @PatchMapping("/{meetingId}/apply")
+    @PatchMapping("/{meetingId}/cancel")
     @Operation(summary = "모임 참가 취소", description = "유저가 모임 참가를 취소합니다.")
     public ResponseEntity<MeetingApplicationResponseDto> cancelMeetingApplication(@PathVariable("meetingId") Long meetingId){
         MeetingApplicationResponseDto response = meetingService.cancelMeetingApplication(meetingId);

--- a/src/main/java/findme/dangdangcrew/meeting/service/MeetingService.java
+++ b/src/main/java/findme/dangdangcrew/meeting/service/MeetingService.java
@@ -15,26 +15,14 @@ import findme.dangdangcrew.meeting.repository.MeetingRepository;
 import findme.dangdangcrew.notification.event.ApplyEvent;
 import findme.dangdangcrew.notification.event.NewMeetingEvent;
 import findme.dangdangcrew.place.domain.Place;
-import findme.dangdangcrew.place.service.HotPlaceService;
 import findme.dangdangcrew.place.service.PlaceService;
 import findme.dangdangcrew.user.entity.User;
-import findme.dangdangcrew.user.repository.UserRepository;
+import findme.dangdangcrew.user.service.UserService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-
-
-/*
- * TODO
- *  1. when : 장소 도메인 작성 후
- *     what : 연관관계 매핑, 장소별 모임 조회 메소드 작성
- *  2. when : 채팅방 구현이 어느정도 된 후
- *     what : 모임 채팅방 참여 api
- *  3. 내가 참여한 모임 조회 구현
- * */
 
 @Service
 @RequiredArgsConstructor
@@ -43,7 +31,7 @@ public class MeetingService {
     private final MeetingRepository meetingRepository;
     private final MeetingMapper meetingMapper;
     private final UserMeetingService userMeetingService;
-    private final UserRepository userRepository;
+    private final UserService userService;
     private final EventPublisher eventPublisher;
     private final PlaceService placeService;
     private final ChatRoomService chatRoomService;
@@ -53,21 +41,16 @@ public class MeetingService {
         return meetingRepository.findByIdAndStatus(id, MeetingStatus.IN_PROGRESS).orElseThrow(() -> new CustomException(ErrorCode.MEETING_NOT_FOUND));
     }
 
-    /*
-     * TODO
-     *  when : 유저 로그인 / 토큰 구현된 후
-     *  what : 매개변수 부분 수정
-     * */
     // 모임 생성
     @Transactional
-    public MeetingApplicationResponseDto create(MeetingRequestDto meetingRequestDto, Long userId) {
+    public MeetingApplicationResponseDto create(MeetingRequestDto meetingRequestDto) {
         Place place = placeService.findOrCreatePlace(meetingRequestDto.getPlaceRequestDto());
         Meeting meeting = meetingMapper.toEntity(meetingRequestDto, place);
         meeting = meetingRepository.save(meeting);
         chatRoomService.createChatRoom(meeting);
-        eventPublisher.publisher(new NewMeetingEvent(place.getPlaceName(),meeting.getId(),place.getId()));
+        eventPublisher.publisher(new NewMeetingEvent(place.getPlaceName(), meeting.getId(), place.getId()));
 
-        User user = userRepository.findById(userId).orElseThrow();
+        User user = userService.getCurrentUser();
         UserMeeting userMeeting = userMeetingService.saveUserAndMeeting(meeting, user, UserMeetingStatus.LEADER);
 
         return meetingMapper.toApplicationDto(userMeeting);
@@ -79,16 +62,11 @@ public class MeetingService {
         return meetingMapper.toDto(meeting);
     }
 
-    /*
-    * TODO
-    *  when : 유저 로그인 / 토큰 구현된 후
-    *  what : 매개변수 부분 수정
-    * */
     // 모임 참가 신청
     @Transactional
-    public MeetingApplicationResponseDto applyMeetingByMeetingId(Long id, Long userId) {
+    public MeetingApplicationResponseDto applyMeetingByMeetingId(Long id) {
         Meeting meeting = findProgressMeeting(id);
-        User user = userRepository.findById(userId).orElseThrow();
+        User user = userService.getCurrentUser();
         Place place = meeting.getPlace();
 
         UserMeeting userMeeting = userMeetingService.saveUserAndMeeting(meeting, user, UserMeetingStatus.WAITING);
@@ -101,9 +79,9 @@ public class MeetingService {
 
     // 모임 참가 취소
     @Transactional
-    public MeetingApplicationResponseDto cancelMeetingApplication(Long id, Long userId) {
+    public MeetingApplicationResponseDto cancelMeetingApplication(Long id) {
         Meeting meeting = findProgressMeeting(id);
-        User user = userRepository.findById(userId).orElseThrow();
+        User user = userService.getCurrentUser();
 
         UserMeeting userMeeting = userMeetingService.cancelMeetingApplication(meeting, user);
 
@@ -117,17 +95,11 @@ public class MeetingService {
 
     // 모임 신청 상태 변경(모임 생성자)
     @Transactional
-    public MeetingApplicationResponseDto changeMeetingApplicationStatusByLeader(Long id, MeetingApplicationUpdateRequestDto dto){
+    public MeetingApplicationResponseDto changeMeetingApplicationStatusByLeader(Long id, MeetingApplicationUpdateRequestDto dto) {
         Meeting meeting = findProgressMeeting(id);
-        User user = userRepository.findById(dto.getUserId()).orElseThrow();
+        User user = userService.getCurrentUser();
 
-        /*
-         * TODO
-         *  1. when : 유저 로그인 / 토큰 구현된 후
-         *     what : 로그인 유저가 해당 모임 리더인지 확인
-         * */
-
-        UserMeeting userMeeting = userMeetingService.findUserMeeting(meeting, user);
+        UserMeeting userMeeting = userMeetingService.checkLeaderPermission(meeting);
         UserMeetingStatus currentStatus = userMeeting.getStatus();
         UserMeetingStatus newStatus = dto.getStatus();
 
@@ -146,14 +118,11 @@ public class MeetingService {
     public List<MeetingApplicationResponseDto> readAllApplications(Long id) {
         Meeting meeting = findProgressMeeting(id);
 
-        /*
-         * TODO
-         *  when : 유저 로그인 / 토큰 구현된 후
-         *  what : 로그인 유저가 해당 모임 리더인지 확인
-         * */
+        userMeetingService.checkLeaderPermission(meeting);
 
         List<UserMeeting> userMeetings = userMeetingService.findWaitingByMeetingId(meeting);
         return meetingMapper.toListApplicationDto(userMeetings);
+
     }
 
     // 모임 확정자 조회
@@ -172,22 +141,22 @@ public class MeetingService {
 
     // 모임 수정
     @Transactional
-    public MeetingDetailResponseDto updateMeeting(Long id, MeetingRequestDto meetingRequestDto){
+    public MeetingDetailResponseDto updateMeeting(Long id, MeetingRequestDto meetingRequestDto) {
         Meeting meeting = findProgressMeeting(id);
-
+        userMeetingService.checkLeaderPermission(meeting);
         meeting.updateMeeting(
                 meetingRequestDto.getMeetingName(),
                 meetingRequestDto.getInformation(),
                 meetingRequestDto.getMaxPeople()
         );
-
         return meetingMapper.toDto(meeting);
     }
 
     // 모임 삭제
     @Transactional
-    public void deleteMeeting(Long id){
+    public void deleteMeeting(Long id) {
         Meeting meeting = findProgressMeeting(id);
+        userMeetingService.checkLeaderPermission(meeting);
         meeting.updateMeetingStatus(MeetingStatus.DELETED);
         userMeetingService.delete(meeting);
     }

--- a/src/main/java/findme/dangdangcrew/meeting/service/MeetingService.java
+++ b/src/main/java/findme/dangdangcrew/meeting/service/MeetingService.java
@@ -83,7 +83,7 @@ public class MeetingService {
         Meeting meeting = findProgressMeeting(id);
         User user = userService.getCurrentUser();
 
-        UserMeeting userMeeting = userMeetingService.cancelMeetingApplication(meeting, user);
+        UserMeeting userMeeting = userMeetingService.updateMeetingStatus(meeting, user, UserMeetingStatus.CANCELLED);
 
         /*
          * TODO
@@ -110,7 +110,7 @@ public class MeetingService {
             meeting.decreaseCurPeople();
         }
 
-        userMeeting = userMeetingService.updateMeetingApplication(meeting, user, dto.getStatus());
+        userMeeting = userMeetingService.updateMeetingStatus(meeting, user, dto.getStatus());
         return meetingMapper.toApplicationDto(userMeeting);
     }
 

--- a/src/main/java/findme/dangdangcrew/meeting/service/UserMeetingService.java
+++ b/src/main/java/findme/dangdangcrew/meeting/service/UserMeetingService.java
@@ -57,24 +57,15 @@ public class UserMeetingService {
         return userMeeting.getUser();
     }
 
-    // 신청 취소 - 일반 유저
     @Transactional
-    public UserMeeting cancelMeetingApplication(Meeting meeting, User user) {
+    public UserMeeting updateMeetingStatus(Meeting meeting, User user, UserMeetingStatus newStatus) {
         UserMeeting userMeeting = findUserMeeting(meeting, user);
-        if(userMeeting.getStatus() == UserMeetingStatus.WAITING) {
-            userMeeting.updateStatus(UserMeetingStatus.CANCELLED);
+        if(userMeeting.getStatus() != newStatus) {
+            userMeeting.updateStatus(newStatus);
             return userMeeting;
         } else {
-            throw new IllegalArgumentException("취소할 수 없습니다.");
+            throw new CustomException(ErrorCode.NOT_CHANGE);
         }
-    }
-
-    // 신청 상태 변경 - 모임 생성자
-    @Transactional
-    public UserMeeting updateMeetingApplication(Meeting meeting, User user, UserMeetingStatus status) {
-        UserMeeting userMeeting = findUserMeeting(meeting, user);
-        userMeeting.updateStatus(status);
-        return userMeeting;
     }
 
     // 모임 신청자 전체 조회 - 모임 생성자

--- a/src/main/java/findme/dangdangcrew/meeting/service/UserMeetingService.java
+++ b/src/main/java/findme/dangdangcrew/meeting/service/UserMeetingService.java
@@ -1,10 +1,13 @@
 package findme.dangdangcrew.meeting.service;
 
+import findme.dangdangcrew.global.exception.CustomException;
+import findme.dangdangcrew.global.exception.ErrorCode;
 import findme.dangdangcrew.meeting.entity.Meeting;
 import findme.dangdangcrew.meeting.entity.UserMeeting;
 import findme.dangdangcrew.meeting.entity.enums.UserMeetingStatus;
 import findme.dangdangcrew.meeting.repository.UserMeetingRepository;
 import findme.dangdangcrew.user.entity.User;
+import findme.dangdangcrew.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,10 +20,22 @@ import java.util.List;
 public class UserMeetingService {
 
     private final UserMeetingRepository userMeetingRepository;
+    private final UserService userService;
 
     public UserMeeting findUserMeeting(Meeting meeting, User user) {
         return userMeetingRepository.findFirstByMeeting_IdAndUser_Id(meeting.getId(), user.getId())
                 .orElseThrow(() -> new IllegalArgumentException("해당 유저는 이 모임에 속해있지 않습니다."));
+    }
+
+    // 리더 확인
+    public UserMeeting checkLeaderPermission(Meeting meeting) {
+        User user = userService.getCurrentUser();
+
+        UserMeeting userMeeting = findUserMeeting(meeting, user);
+        if (userMeeting.getStatus() != UserMeetingStatus.LEADER) {
+            throw new CustomException(ErrorCode.NOT_LEADER);
+        }
+        return userMeeting;
     }
 
     // 유저가 미팅에 참가


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 문서 수정
- [X] 코드 리팩토링
- [ ] 테스트 코드 추가 및 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
dev

### 이슈
- closed. #53 

### 변경 사항
1. 기존 userId로 회원 정보를 가져왔으나 로그인한 유저의 정보를 가져오도록 수정하였습니다.
2. 로그인한 유저의 모임 권한을 확인 후, 리더가 아닐 경우 삭제/수정/다른 유저의 신청상태 변경을 제한합니다.

### 테스트 결과
로그인한 유저가 리더가 아닐 경우 예외처리
1. 다른 유저의 상태 변경 제한
<img width="707" alt="image" src="https://github.com/user-attachments/assets/d3bd021b-e890-41e6-98c7-05d8d284769d" />
2. 모임 수정 제한
<img width="919" alt="image" src="https://github.com/user-attachments/assets/364bfd79-a985-4da6-a0be-ea505fbedc8c" />
3. 모임 삭제 제한
<img width="629" alt="image" src="https://github.com/user-attachments/assets/08d04b5c-0422-42d7-815f-3a55dc3240cb" />
4. 신청자 조회 제한
<img width="1038" alt="image" src="https://github.com/user-attachments/assets/957d0b83-5027-45b9-8eb0-636ce5e4fd03" />
