### PR TITLE
[#68] 모임 참가 취소시 평가점수 감소 구현

### DIFF
--- a/src/main/java/findme/dangdangcrew/meeting/controller/MeetingController.java
+++ b/src/main/java/findme/dangdangcrew/meeting/controller/MeetingController.java
@@ -32,14 +32,14 @@ public class MeetingController {
         return ResponseEntity.ok(response);
     }
 
-    @PostMapping("/{meetingId}/apply")
+    @PostMapping("/{meetingId}/applications/apply")
     @Operation(summary = "모임 참가 신청", description = "유저가 모임 참가 신청합니다.")
     public ResponseEntity<MeetingApplicationResponseDto> applyMeeting(@PathVariable("meetingId") Long meetingId){
         MeetingApplicationResponseDto response = meetingService.applyMeetingByMeetingId(meetingId);
         return ResponseEntity.ok(response);
     }
 
-    @PatchMapping("/{meetingId}/cancel")
+    @PatchMapping("/{meetingId}/applications/cancel")
     @Operation(summary = "모임 참가 취소", description = "유저가 모임 참가를 취소합니다.")
     public ResponseEntity<MeetingApplicationResponseDto> cancelMeetingApplication(@PathVariable("meetingId") Long meetingId){
         MeetingApplicationResponseDto response = meetingService.cancelMeetingApplication(meetingId);

--- a/src/main/java/findme/dangdangcrew/meeting/service/MeetingService.java
+++ b/src/main/java/findme/dangdangcrew/meeting/service/MeetingService.java
@@ -101,6 +101,7 @@ public class MeetingService {
 
         UserMeeting userMeeting = userMeetingService.checkLeaderPermission(meeting);
         UserMeetingStatus currentStatus = userMeeting.getStatus();
+        User changeUser = userService.getUser(dto.getUserId());
         UserMeetingStatus newStatus = dto.getStatus();
 
         if ((currentStatus == UserMeetingStatus.CANCELLED || currentStatus == UserMeetingStatus.WAITING)
@@ -110,7 +111,7 @@ public class MeetingService {
             meeting.decreaseCurPeople();
         }
 
-        userMeeting = userMeetingService.updateMeetingStatus(meeting, user, dto.getStatus());
+        userMeeting = userMeetingService.updateMeetingStatus(meeting, changeUser, dto.getStatus());
         return meetingMapper.toApplicationDto(userMeeting);
     }
 

--- a/src/main/java/findme/dangdangcrew/meeting/service/UserMeetingService.java
+++ b/src/main/java/findme/dangdangcrew/meeting/service/UserMeetingService.java
@@ -61,10 +61,17 @@ public class UserMeetingService {
     public UserMeeting updateMeetingStatus(Meeting meeting, User user, UserMeetingStatus newStatus) {
         UserMeeting userMeeting = findUserMeeting(meeting, user);
         if(userMeeting.getStatus() != newStatus) {
+            deductAvgScore(userMeeting, user);
             userMeeting.updateStatus(newStatus);
             return userMeeting;
         } else {
             throw new CustomException(ErrorCode.NOT_CHANGE);
+        }
+    }
+
+    private void deductAvgScore(UserMeeting userMeeting, User user) {
+        if(userMeeting.getStatus() == UserMeetingStatus.CONFIRMED) {
+            user.deductUserScore();
         }
     }
 

--- a/src/main/java/findme/dangdangcrew/meeting/service/UserMeetingService.java
+++ b/src/main/java/findme/dangdangcrew/meeting/service/UserMeetingService.java
@@ -69,7 +69,8 @@ public class UserMeetingService {
         }
     }
 
-    private void deductAvgScore(UserMeeting userMeeting, User user) {
+    @Transactional
+    protected void deductAvgScore(UserMeeting userMeeting, User user) {
         if(userMeeting.getStatus() == UserMeetingStatus.CONFIRMED) {
             user.deductUserScore();
         }

--- a/src/main/java/findme/dangdangcrew/user/entity/User.java
+++ b/src/main/java/findme/dangdangcrew/user/entity/User.java
@@ -66,4 +66,8 @@ import java.time.LocalDateTime;
     public void updatePassword(String newPassword) {
         this.password = newPassword;
     }
+
+    public void deductUserScore() {
+        this.userScore = userScore.subtract(BigDecimal.valueOf(0.5));
+    }
 }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [X] 기능 추가
- [ ] 기능 삭제
- [X] 버그 수정
- [ ] 문서 수정
- [X] 코드 리팩토링
- [ ] 테스트 코드 추가 및 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
dev

### 이슈
- closed #68 

### 변경 사항
1. 엔드포인트가 충돌되어 실행되지 않아 `MeetingController` 수정했습니다.
2. 모임장이 모임 신청자를 모임 확정할 경우, 기존에는 dto에 담긴 userId가 아닌 로그인한 유저의 상태를 업데이트하도록 작성되어 있어 수정하였습니다.
3. User 엔티티에 평가점수 감소 메소드 추가했습니다.
- 해당 유저의 UserMeetingStatus가 `CONFIRMED`일 때 취소하면, `avg_score`를 0.5점 깎도록 구현하였습니다.

### 테스트 결과
<img width="651" alt="image" src="https://github.com/user-attachments/assets/d8db0e59-5c86-4453-b1a7-0d6d48db6c4b" />
7번 유저는 확정 후 취소했을 경우이고, 8번 유저는 확정 전 취소했을 때입니다.