### PR TITLE
[#74] LeaderAction 알림 기능 추가

### DIFF
--- a/src/main/java/findme/dangdangcrew/global/exception/ErrorCode.java
+++ b/src/main/java/findme/dangdangcrew/global/exception/ErrorCode.java
@@ -47,6 +47,9 @@ public enum ErrorCode {
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
     MISSING_TOKEN(HttpStatus.BAD_REQUEST, "토큰이 누락되었습니다."),
 
+    // LeaderType Error
+    INVALID_LEADER_ACTION_TYPE(HttpStatus.BAD_REQUEST, "유효하지 않은 LeaderActionType 입니다."),
+
     ;
 
     private final HttpStatus status;

--- a/src/main/java/findme/dangdangcrew/meeting/dto/MeetingApplicationUpdateRequestDto.java
+++ b/src/main/java/findme/dangdangcrew/meeting/dto/MeetingApplicationUpdateRequestDto.java
@@ -7,9 +7,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@Builder
 @NoArgsConstructor
-@AllArgsConstructor
 public class MeetingApplicationUpdateRequestDto {
     private Long userId;
 

--- a/src/main/java/findme/dangdangcrew/meeting/dto/MeetingApplicationUpdateRequestDto.java
+++ b/src/main/java/findme/dangdangcrew/meeting/dto/MeetingApplicationUpdateRequestDto.java
@@ -1,11 +1,15 @@
 package findme.dangdangcrew.meeting.dto;
 
 import findme.dangdangcrew.meeting.entity.enums.UserMeetingStatus;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class MeetingApplicationUpdateRequestDto {
     private Long userId;
 

--- a/src/main/java/findme/dangdangcrew/meeting/service/MeetingService.java
+++ b/src/main/java/findme/dangdangcrew/meeting/service/MeetingService.java
@@ -13,6 +13,8 @@ import findme.dangdangcrew.meeting.entity.enums.UserMeetingStatus;
 import findme.dangdangcrew.meeting.mapper.MeetingMapper;
 import findme.dangdangcrew.meeting.repository.MeetingRepository;
 import findme.dangdangcrew.notification.event.ApplyEvent;
+import findme.dangdangcrew.notification.event.LeaderActionEvent;
+import findme.dangdangcrew.notification.event.LeaderActionType;
 import findme.dangdangcrew.notification.event.NewMeetingEvent;
 import findme.dangdangcrew.place.domain.Place;
 import findme.dangdangcrew.place.service.PlaceService;
@@ -104,6 +106,7 @@ public class MeetingService {
         User changeUser = userService.getUser(dto.getUserId());
         UserMeetingStatus newStatus = dto.getStatus();
 
+        LeaderActionType leaderActionType = LeaderActionType.JOIN_REJECTED;
         if ((currentStatus == UserMeetingStatus.CANCELLED || currentStatus == UserMeetingStatus.WAITING)
                 && newStatus == UserMeetingStatus.CONFIRMED) {
             meeting.increaseCurPeople();

--- a/src/main/java/findme/dangdangcrew/notification/converter/ApplyNotificationConverter.java
+++ b/src/main/java/findme/dangdangcrew/notification/converter/ApplyNotificationConverter.java
@@ -21,8 +21,8 @@ public class ApplyNotificationConverter implements NotificationConverter{
                 notificationEntity.getTargetUserId(),
                 notificationEntity.getMessage(),
                 notificationEntity.isRead(),
-                notificationEntity.getApplyUserId(),
                 notificationEntity.getMeetingId(),
+                notificationEntity.getApplyUserId(),
                 notificationEntity.getCreatedAt());
     }
 

--- a/src/main/java/findme/dangdangcrew/notification/converter/LeaderActionNotificationConverter.java
+++ b/src/main/java/findme/dangdangcrew/notification/converter/LeaderActionNotificationConverter.java
@@ -1,0 +1,46 @@
+package findme.dangdangcrew.notification.converter;
+
+import findme.dangdangcrew.global.exception.CustomException;
+import findme.dangdangcrew.global.exception.ErrorCode;
+import findme.dangdangcrew.notification.domain.*;
+
+public class LeaderActionNotificationConverter implements NotificationConverter {
+
+    @Override
+    public boolean canConvert(NotificationEntity notificationEntity) {
+        return notificationEntity.getNotificationType() == NotificationType.LEADER_ACTION;
+    }
+
+    @Override
+    public Notification convert(NotificationEntity notificationEntity) {
+        return new LeaderActionNotification(
+                notificationEntity.getId(),
+                notificationEntity.getTargetUserId(),
+                notificationEntity.getMessage(),
+                notificationEntity.isRead(),
+                notificationEntity.getMeetingId(),
+                notificationEntity.getMeetingLeaderId(),
+                notificationEntity.getCreatedAt());
+    }
+
+    @Override
+    public boolean canConvertToEntity(Notification notification) {
+        return notification.getNotificationType() == NotificationType.LEADER_ACTION;
+    }
+
+    @Override
+    public NotificationEntity convertToEntity(Notification notification) {
+        if (!(notification instanceof LeaderActionNotification leaderActionNotification)) {
+            throw new CustomException(ErrorCode.INVALID_NOTIFICATION_TYPE);
+        }
+        return NotificationEntity.builder()
+                .targetUserId(leaderActionNotification.getTargetUserId())
+                .message(leaderActionNotification.getMessage())
+                .isRead(leaderActionNotification.isRead())
+                .createdAt(leaderActionNotification.getCreatedAt())
+                .meetingId(leaderActionNotification.getMeetingId())
+                .applyUserId(leaderActionNotification.getMeetingLeaderId())
+                .notificationType(leaderActionNotification.getNotificationType())
+                .build();
+    }
+}

--- a/src/main/java/findme/dangdangcrew/notification/domain/LeaderActionNotification.java
+++ b/src/main/java/findme/dangdangcrew/notification/domain/LeaderActionNotification.java
@@ -1,0 +1,25 @@
+package findme.dangdangcrew.notification.domain;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+public class LeaderActionNotification extends Notification{
+    private Long meetingLeaderId;
+    private Long meetingId;
+
+    public LeaderActionNotification(Long targetUserId, String message, boolean isRead, Long meetingId, Long meetingLeaderId, LocalDateTime createdAt) {
+        super(null, targetUserId, message, isRead, NotificationType.APPLY_MEETING, createdAt); // 저장 시 id 없이 생성
+        this.meetingLeaderId = meetingLeaderId;
+        this.meetingId = meetingId;
+    }
+
+    public LeaderActionNotification(Long id, Long targetUserId, String message, boolean isRead, Long meetingId, Long meetingLeaderId, LocalDateTime createdAt) {
+        super(id, targetUserId, message, isRead, NotificationType.APPLY_MEETING, createdAt); // 조회 시 id 포함
+        this.meetingLeaderId = meetingLeaderId;
+        this.meetingId = meetingId;
+    }
+}

--- a/src/main/java/findme/dangdangcrew/notification/domain/NotificationEntity.java
+++ b/src/main/java/findme/dangdangcrew/notification/domain/NotificationEntity.java
@@ -21,6 +21,7 @@ public class NotificationEntity {
     private String placeId;
     private Long meetingId;
     private Long applyUserId;
+    private Long meetingLeaderId;
     private String message;
     private boolean isRead;
     private LocalDateTime createdAt;
@@ -28,11 +29,12 @@ public class NotificationEntity {
     private NotificationType notificationType;
 
     @Builder
-    public NotificationEntity(Long targetUserId,String placeId, Long meetingId,Long applyUserId, String message, boolean isRead, LocalDateTime createdAt, NotificationType notificationType){
+    public NotificationEntity(Long targetUserId,String placeId, Long meetingId,Long applyUserId,Long meetingLeaderId, String message, boolean isRead, LocalDateTime createdAt, NotificationType notificationType){
         this.targetUserId =targetUserId;
         this.placeId = placeId;
         this.meetingId = meetingId;
         this.applyUserId = applyUserId;
+        this.meetingLeaderId = meetingLeaderId;
         this.message = message;
         this.isRead = isRead;
         this.createdAt = createdAt;

--- a/src/main/java/findme/dangdangcrew/notification/domain/NotificationType.java
+++ b/src/main/java/findme/dangdangcrew/notification/domain/NotificationType.java
@@ -3,5 +3,6 @@ package findme.dangdangcrew.notification.domain;
 public enum NotificationType {
     MEETING_CREATED,
     HOT_PLACE,
-    APPLY_MEETING
+    APPLY_MEETING,
+    LEADER_ACTION
 }

--- a/src/main/java/findme/dangdangcrew/notification/event/LeaderActionEvent.java
+++ b/src/main/java/findme/dangdangcrew/notification/event/LeaderActionEvent.java
@@ -1,0 +1,14 @@
+package findme.dangdangcrew.notification.event;
+
+/**
+ * @param targetUserId 알림 받을 유저 (모임 참가 희망자)
+ * @param meetingName 모임 이름
+ **/
+public record LeaderActionEvent(
+        Long targetUserId,
+        Long meetingLeaderId,
+        Long meetingId,
+        String meetingName,
+        LeaderActionType leaderActionType
+) {
+}

--- a/src/main/java/findme/dangdangcrew/notification/event/LeaderActionType.java
+++ b/src/main/java/findme/dangdangcrew/notification/event/LeaderActionType.java
@@ -1,0 +1,7 @@
+package findme.dangdangcrew.notification.event;
+
+public enum LeaderActionType {
+    JOIN_ACCEPTED,
+    JOIN_REJECTED,
+    KICK_OUT
+}

--- a/src/main/java/findme/dangdangcrew/notification/event/NotificationEventListener.java
+++ b/src/main/java/findme/dangdangcrew/notification/event/NotificationEventListener.java
@@ -1,5 +1,7 @@
 package findme.dangdangcrew.notification.event;
 
+import findme.dangdangcrew.global.exception.CustomException;
+import findme.dangdangcrew.global.exception.ErrorCode;
 import findme.dangdangcrew.notification.domain.ApplyNotification;
 import findme.dangdangcrew.notification.domain.HotPlaceNotification;
 import findme.dangdangcrew.notification.domain.NewMeetingNotification;
@@ -30,7 +32,7 @@ public class NotificationEventListener {
     @EventListener
     public void handleNewMeetingNotification(NewMeetingEvent event) {
         // 보낼 메세지
-        String message = "[" + event.placeName() + "]" + " 에 새로운 모임이 생성되었습니다";
+        String message = makeNewMeetingMessage(event);
 
         // 생성 시각
         LocalDateTime createdAt = LocalDateTime.now();
@@ -62,7 +64,7 @@ public class NotificationEventListener {
     @EventListener
     public void handleHotPlaceNotification(HotPlaceEvent event) {
         // 보낼 메세지
-        String message = "[" + event.placeName() + "]" + " 인기 폭발! 많은 사람들이 관심을 가지고 있어요.";
+        String message = makeHotPlaceMessage(event);
 
         // 생성 시각
         LocalDateTime createdAt = LocalDateTime.now();
@@ -89,7 +91,7 @@ public class NotificationEventListener {
     @EventListener
     public void handleApplyNotification(ApplyEvent event) {
         // 보낼 메세지
-        String message = event.nickname() + " 님께서 "+event.meetingName()+ " 에 참여 하고 싶어 합니다.";
+        String message = makeApplyMessage(event);
 
         // 생성 시각
         LocalDateTime createdAt = LocalDateTime.now();
@@ -109,4 +111,54 @@ public class NotificationEventListener {
         // 비동기 알림 보내기, 새로운 쓰레드에는 트랜잭션이 전파되지 않음
         sseService.sendNotificationToClient(event.targetUserId(), message);
     }
+
+    @EventListener
+    public void handleLeaderActionNotification(LeaderActionEvent event) {
+        // 보낼 메세지
+        String message = makeLeaderActionMessage(event);
+
+        // 생성 시각
+        LocalDateTime createdAt = LocalDateTime.now();
+
+        // MeetingNotification 생성
+        Notification notification = new ApplyNotification(
+                event.targetUserId(),
+                message,
+                false,
+                event.meetingId(),
+                event.meetingLeaderId(),
+                createdAt
+        );
+
+        notificationService.saveNotification(notification);
+
+        // 비동기 알림 보내기, 새로운 쓰레드에는 트랜잭션이 전파되지 않음
+        sseService.sendNotificationToClient(event.targetUserId(), message);
+    }
+
+    private String makeNewMeetingMessage(NewMeetingEvent event) {
+        return "[" + event.placeName() + "]" + " 에 새로운 모임이 생성되었습니다";
+    }
+
+    private String makeHotPlaceMessage(HotPlaceEvent event) {
+        return "[" + event.placeName() + "]" + " 인기 폭발! 많은 사람들이 관심을 가지고 있어요.";
+    }
+
+    private String makeApplyMessage(ApplyEvent event) {
+        return event.nickname() + " 님께서 " + event.meetingName() + " 에 참여 하고 싶어 합니다.";
+    }
+    private String makeLeaderActionMessage(LeaderActionEvent event) {
+        LeaderActionType leaderActionType = event.leaderActionType();
+        if(leaderActionType == LeaderActionType.JOIN_REJECTED)
+            return "["+event.meetingName()+"]" + " 모임 참가 신청이 반려되었습니다.";
+
+        if(leaderActionType == LeaderActionType.JOIN_ACCEPTED)
+            return "["+event.meetingName()+"]" + " 모임 참가 신청이 승낙되었습니다.";
+
+        if(leaderActionType == LeaderActionType.KICK_OUT)
+            return "["+event.meetingName()+"]" + " 모임에서 강퇴되었습니다.";
+
+        throw new CustomException(ErrorCode.INVALID_LEADER_ACTION_TYPE);
+    }
+
 }

--- a/src/main/java/findme/dangdangcrew/sse/service/SseService.java
+++ b/src/main/java/findme/dangdangcrew/sse/service/SseService.java
@@ -91,7 +91,7 @@ public class SseService {
 
     }
 
-    // 유저가 모임 참가 신청 할때 모임장이 받을 실시간 알림
+    // 유저가 모임 참가 신청 (모임장 알림) | 모임 참가 신청 결과 알림 (참가 신청 유저 알림)
     @Async
     public void sendNotificationToClient(Long userId, String message){
         SseEmitter sseEmitter = emitterRepository.findEmitterByUserId(userId);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,7 +7,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     properties:
       hibernate:
         dialect: org.hibernate.dialect.MySQL8Dialect

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,7 +7,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
     properties:
       hibernate:
         dialect: org.hibernate.dialect.MySQL8Dialect


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [X] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 문서 수정
- [ ] 코드 리팩토링
- [ ] 테스트 코드 추가 및 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
dev

### 이슈
- closed #74 

### 변경 사항
1. LeaderActionNotification 추가
- 모임장이 모임 참가 신청을 승낙, 거절 할 수 있고, 또한 신청이 승낙 된 유저를 강퇴할 수 있습니다. 이 때 해당 결과를 모임에 참가를 신청한 유저가 알 수 있도록 해당알림을 추가하였습니다.
- LeaderActionType 은 JOIN_ACCEPTED, JOIN_REJECTED, KICK_OUT 이 있습니다.
2. MeetingService 에서  LeaderActionEvent 발행
- changeMeetingApplicationStatusByLeader 메서드에서, LeaderActionEvent를 발행하게 하였습니다.

### 테스트 결과
![image](https://github.com/user-attachments/assets/7c3fd744-476f-4db1-8adb-e9f9724f56fa)
