### PR TITLE
[#65] 토큰에서 user 정보 추출 로직 반영해서 리팩토링

### DIFF
--- a/src/main/java/findme/dangdangcrew/chat/controller/ChatController.java
+++ b/src/main/java/findme/dangdangcrew/chat/controller/ChatController.java
@@ -3,10 +3,10 @@ package findme.dangdangcrew.chat.controller;
 import findme.dangdangcrew.chat.dto.ChatMessageRequestDto;
 import findme.dangdangcrew.chat.dto.ChatMessageResponseDto;
 import findme.dangdangcrew.chat.service.ChatRoomService;
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.Header;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.messaging.handler.annotation.SendTo;
@@ -16,23 +16,15 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class ChatController {
 
-    private final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
     private final ChatRoomService chatRoomService;
 
     @MessageMapping("/chat.{roomId}")
     @SendTo("/subscribe/chatroom.{roomId}")
     public ChatMessageResponseDto handleChat(
             @DestinationVariable Long roomId,
-            @Payload ChatMessageRequestDto chatMessage) {
+            @Payload ChatMessageRequestDto chatMessage,
+            @Header("simpSessionAttributes") Map<String, Object> sessionAttributes) {
 
-        Long userId = 1L; // 토큰 값에서 User 정보 추출해오는 로직이 없어서 에러가 생겨서 일단 임시로 넣어놓음.
-        String message = chatRoomService.processChat(chatMessage, roomId, userId); // 추후 토큰 기반 유저 정보 추출이 개발되면 userId 파라미터 삭제 예정.
-
-        return new ChatMessageResponseDto(
-                String.valueOf(roomId),
-                chatMessage.getSender(),
-                message,
-                LocalDateTime.now().format(formatter)
-        );
+        return chatRoomService.processChat(chatMessage, roomId, sessionAttributes);
     }
 }

--- a/src/main/java/findme/dangdangcrew/chat/dto/ChatMessageRequestDto.java
+++ b/src/main/java/findme/dangdangcrew/chat/dto/ChatMessageRequestDto.java
@@ -9,6 +9,5 @@ public class ChatMessageRequestDto {
     }
 
     private MessageType type;
-    private String sender;
     private String message;
 }

--- a/src/main/java/findme/dangdangcrew/chat/dto/ChatMessageResponseDto.java
+++ b/src/main/java/findme/dangdangcrew/chat/dto/ChatMessageResponseDto.java
@@ -1,10 +1,12 @@
 package findme.dangdangcrew.chat.dto;
 
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
 
 @Data
 @AllArgsConstructor
+@Builder
 public class ChatMessageResponseDto {
     private String roomId;
     private String sender;

--- a/src/main/java/findme/dangdangcrew/chat/service/ChatMessageService.java
+++ b/src/main/java/findme/dangdangcrew/chat/service/ChatMessageService.java
@@ -4,6 +4,8 @@ import findme.dangdangcrew.chat.dto.ChatMessageRequestDto;
 import findme.dangdangcrew.chat.dto.ChatMessageResponseDto;
 import findme.dangdangcrew.chat.entity.ChatMessage;
 import findme.dangdangcrew.chat.repository.ChatMessageRepository;
+import findme.dangdangcrew.user.entity.User;
+import findme.dangdangcrew.user.service.UserService;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -18,8 +20,8 @@ public class ChatMessageService {
 
     private final ChatMessageRepository chatMessageRepository;
 
-    public void saveMessage(ChatMessageRequestDto chatMessageRequestDto, Long roomId) {
-        ChatMessage chatMessage = ChatMessage.create(roomId, chatMessageRequestDto.getSender(), chatMessageRequestDto.getMessage());
+    public void saveMessage(ChatMessageRequestDto chatMessageRequestDto, Long roomId, User user) {
+        ChatMessage chatMessage = ChatMessage.create(roomId, user.getNickname(), chatMessageRequestDto.getMessage());
         chatMessageRepository.save(chatMessage);
     }
 
@@ -27,12 +29,12 @@ public class ChatMessageService {
     public List<ChatMessageResponseDto> getMessages(Long roomId) {
         List<ChatMessage> chatMessages = chatMessageRepository.findByRoomIdOrderByTimeAsc(roomId);
         return chatMessages.stream()
-                .map(m -> new ChatMessageResponseDto(
-                        String.valueOf(roomId),
-                        m.getSender(),
-                        m.getMessage(),
-                        m.getTime().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"))
-                ))
-                .collect(Collectors.toList());
+            .map(m -> ChatMessageResponseDto.builder()
+                .roomId(String.valueOf(roomId))
+                .sender(m.getSender())
+                .message(m.getMessage())
+                .timestamp(m.getTime().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")))
+                .build())
+            .collect(Collectors.toList());
     }
 }

--- a/src/main/java/findme/dangdangcrew/global/config/WebSocketConfig.java
+++ b/src/main/java/findme/dangdangcrew/global/config/WebSocketConfig.java
@@ -1,6 +1,10 @@
 package findme.dangdangcrew.global.config;
 
+import findme.dangdangcrew.global.interceptor.JwtChannelInterceptor;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
@@ -8,7 +12,11 @@ import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerCo
 
 @Configuration
 @EnableWebSocketMessageBroker
+@RequiredArgsConstructor
+@Slf4j
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    private final JwtChannelInterceptor jwtChannelInterceptor;
 
     @Override
     public void configureMessageBroker(MessageBrokerRegistry registry) {
@@ -20,5 +28,10 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     public void registerStompEndpoints(StompEndpointRegistry registry) {
         registry.addEndpoint("/ws") // 핸드쉐이크를 위한 endpoint
                 .setAllowedOrigins("*");
+    }
+
+    @Override
+    public void configureClientInboundChannel(ChannelRegistration registration) {
+        registration.interceptors(jwtChannelInterceptor);
     }
 }

--- a/src/main/java/findme/dangdangcrew/global/exception/ErrorCode.java
+++ b/src/main/java/findme/dangdangcrew/global/exception/ErrorCode.java
@@ -9,6 +9,7 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode {
     // User Error
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 유저입니다."),
+    NULL_POINT(HttpStatus.BAD_REQUEST, "userId값이 비어있습니다."),
 
     // Place Error
     PLACE_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 장소입니다."),
@@ -38,6 +39,7 @@ public enum ErrorCode {
     CHAT_ROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 채팅방입니다."),
     ALREADY_JOINED(HttpStatus.BAD_REQUEST, "이미 채팅방에 참여한 사용자입니다."),
     ALREADY_LEFT(HttpStatus.BAD_REQUEST, "이미 채팅방을 나간 사용자입니다."),
+    UNAUTHORIZED_SUBSCRIBE(HttpStatus.UNAUTHORIZED, "인증되지 않은 사용자입니다."),
 
     // JWT Token Error
     EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "토큰이 만료되었습니다."),

--- a/src/main/java/findme/dangdangcrew/global/interceptor/JwtChannelInterceptor.java
+++ b/src/main/java/findme/dangdangcrew/global/interceptor/JwtChannelInterceptor.java
@@ -1,0 +1,51 @@
+package findme.dangdangcrew.global.interceptor;
+
+import findme.dangdangcrew.global.config.JwtTokenProvider;
+import findme.dangdangcrew.global.exception.CustomException;
+import findme.dangdangcrew.global.exception.ErrorCode;
+import findme.dangdangcrew.user.entity.User;
+import findme.dangdangcrew.user.repository.UserRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class JwtChannelInterceptor implements ChannelInterceptor {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final UserRepository userRepository;
+
+    @Override
+    public Message<?> preSend(Message<?> message, MessageChannel channel) {
+        StompHeaderAccessor accessor = StompHeaderAccessor.wrap(message);
+
+        // CONNECT 요청일 경우 JWT 검증
+        if (accessor.getCommand() == StompCommand.CONNECT) {
+            List<String> authHeaders = accessor.getNativeHeader("Authorization");
+
+            if (authHeaders == null || authHeaders.isEmpty()) {
+                throw new CustomException(ErrorCode.MISSING_TOKEN);
+            }
+
+            String token = authHeaders.get(0).replace("Bearer ", "");
+            if (!jwtTokenProvider.validateToken(token)) {
+                throw new CustomException(ErrorCode.INVALID_TOKEN);
+            }
+
+            String email = jwtTokenProvider.getEmailFromToken(token);
+            User user = userRepository.findByEmail(email)
+                    .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+            accessor.getSessionAttributes().put("userId", user.getId());
+        }
+
+        return message;
+    }
+}

--- a/src/main/java/findme/dangdangcrew/global/interceptor/JwtChannelInterceptor.java
+++ b/src/main/java/findme/dangdangcrew/global/interceptor/JwtChannelInterceptor.java
@@ -17,7 +17,6 @@ import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
-@Slf4j
 public class JwtChannelInterceptor implements ChannelInterceptor {
 
     private final JwtTokenProvider jwtTokenProvider;


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [X] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 문서 수정
- [X] 코드 리팩토링
- [ ] 테스트 코드 추가 및 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
dev

### 이슈
closed #65 

### 변경 사항
웹소켓 접속(CONNECT 요청) 시 헤더에 토큰값을 전달하여 토큰에서 유저 정보를 추출해서 세션에 userId 저장하고 사용할 수 있도록 수정

### 테스트 결과
- 유저 정보를 dto로 주지 않고 웹소켓 접속 시 헤더에 토큰 값 전달만 해도 채팅한 유저 정보가 잘 전달됨
![image](https://github.com/user-attachments/assets/be4b2ea9-ed35-4316-918f-4a3cff39f025)
